### PR TITLE
Improved land validation job speed & parallelism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyProvinces</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <name>townyprovinces</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -29,7 +29,7 @@ public class TownyProvinces extends JavaPlugin {
 	 * Lock this if you want to change or display the map,
 	 * to avoid concurrent modification problems
 	 */
-	public static final Integer MAP_CHANGE_LOCK = 1;
+	public static final Integer DYNMAP_DISPLAY_LOCK = 1;
 	private static TownyProvinces plugin;
 	private static final Version requiredTownyVersion = Version.fromString("0.99.1.0");
 	

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
@@ -1,13 +1,10 @@
 package io.github.townyadvanced.townyprovinces.data;
 
-import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.util.FileMgmt;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
-import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
-import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import io.github.townyadvanced.townyprovinces.util.FileUtil;
 
 import java.io.File;
@@ -65,7 +62,7 @@ public class DataHandlerUtil {
 	private static String getCoordsAsWriteableString(Province province) {
 		StringBuilder result = new StringBuilder();
 		boolean firstCoord = true;
-		for(TPCoord coord: province.getCoordsInProvince()) {
+		for(TPCoord coord: province.getListOfCoordsInProvince()) {
 			if(firstCoord) {
 				firstCoord = false;
 			} else {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/TownyProvincesDataHolder.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/TownyProvincesDataHolder.java
@@ -1,6 +1,5 @@
 package io.github.townyadvanced.townyprovinces.data;
 
-import com.palmergames.bukkit.towny.object.Coord;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
@@ -75,7 +74,7 @@ public class TownyProvincesDataHolder {
 		return true;
 	}
 
-	public List<TPCoord> getCoordsInProvince(Province province) {
+	public List<TPCoord> getListOfCoordsInProvince(Province province) {
 		List<TPCoord> result = new ArrayList<>();
 		for(Map.Entry<TPCoord,Province> mapEntry: coordProvinceMap.entrySet()) {
 			if(mapEntry.getValue().equals(province)) {
@@ -112,7 +111,7 @@ public class TownyProvincesDataHolder {
 
 
 	public void deleteProvince(Province province, Map<TPCoord,TPCoord> unclaimedCoordsMap) {
-		List<TPCoord> coordsInProvince = province.getCoordsInProvince();
+		List<TPCoord> coordsInProvince = province.getListOfCoordsInProvince();
 		for(TPCoord coord: coordsInProvince) {
 			coordProvinceMap.remove(coord);
 			unclaimedCoordsMap.put(coord,coord);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
@@ -90,24 +90,30 @@ public class DisplayProvincesOnDynmapAction {
 	}
 	
 	private void drawProvinceHomeBlocks() {
-		String border_icon = "coins";
+		String border_icon_id = "coins";
+		MarkerIcon homeBlockIcon = markerapi.getMarkerIcon(border_icon_id);
 		Set<Province> copyOfProvincesSet = new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet());
 		for (Province province : copyOfProvincesSet) {
 			try {
-				if(province.isSea())
-					continue;
 				TPCoord homeBlock = province.getHomeBlock();
-				int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
-				int realHomeBlockZ = homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength();
-
-				MarkerIcon homeBlockIcon = markerapi.getMarkerIcon(border_icon);
 				String homeBlockMarkerId = "province_homeblock_" + homeBlock.getX() + "-" + homeBlock.getZ();
-				
-				String newTownCost = TownyEconomyHandler.getFormattedBalance(province.getNewTownCost());
-				String upkeepTownCost = TownyEconomyHandler.getFormattedBalance(province.getUpkeepTownCost());
-				String markerLabel = Translatable.of("dynmap_province_homeblock_label", newTownCost, upkeepTownCost).translate(Locale.ROOT);
 				Marker homeBlockMarker = homeBlocksMarkerSet.findMarker(homeBlockMarkerId);
-				if (homeBlockMarker == null) {
+
+				if(province.isSea()) {
+					//This is sea. If the marker is there, we need to remove it
+					if(homeBlockMarker == null)
+						continue;
+					homeBlockMarker.deleteMarker();
+					return;
+				} else {
+					//This is land If the marker is not there, we need to add it
+					if(homeBlockMarker != null)
+						continue;
+					int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
+					int realHomeBlockZ = homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength();
+					String newTownCost = TownyEconomyHandler.getFormattedBalance(province.getNewTownCost());
+					String upkeepTownCost = TownyEconomyHandler.getFormattedBalance(province.getUpkeepTownCost());
+					String markerLabel = Translatable.of("dynmap_province_homeblock_label", newTownCost, upkeepTownCost).translate(Locale.ROOT);
 					homeBlockMarker = homeBlocksMarkerSet.createMarker(
 						homeBlockMarkerId, markerLabel, TownyProvincesSettings.getWorldName(),
 						realHomeBlockX, 64, realHomeBlockZ,

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
@@ -28,7 +28,7 @@ public class DisplayProvincesOnDynmapAction {
 	private final MarkerAPI markerapi;
 	private MarkerSet bordersMarkerSet;
 	private MarkerSet homeBlocksMarkerSet;
-	private TPFreeCoord tpFreeCoord;
+	private final TPFreeCoord tpFreeCoord;
 
 	public DisplayProvincesOnDynmapAction() {
 		TownyProvinces.info("Enabling dynmap support.");
@@ -91,7 +91,8 @@ public class DisplayProvincesOnDynmapAction {
 	
 	private void drawProvinceHomeBlocks() {
 		String border_icon = "coins";
-		for (Province province : TownyProvincesDataHolder.getInstance().getProvincesSet()) {
+		Set<Province> copyOfProvincesSet = new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet());
+		for (Province province : copyOfProvincesSet) {
 			try {
 				if(province.isSea())
 					continue;
@@ -210,7 +211,7 @@ public class DisplayProvincesOnDynmapAction {
 	 */
 	public static Set<TPCoord> findAllBorderCoords(Province province) {
 		Set<TPCoord> resultSet = new HashSet<>();
-		for(TPCoord provinceCoord: province.getCoordsInProvince()) {
+		for(TPCoord provinceCoord: province.getListOfCoordsInProvince()) {
 			resultSet.addAll(province.getAdjacentBorderCoords(provinceCoord));
 		}
 		return resultSet;
@@ -312,7 +313,7 @@ public class DisplayProvincesOnDynmapAction {
 
 	private void debugDrawProvinceChunks(Province province) {
 		String worldName = TownyProvincesSettings.getWorldName();
-		for(TPCoord tpCoord: TownyProvincesDataHolder.getInstance().getCoordsInProvince(province)) {
+		for(TPCoord tpCoord: TownyProvincesDataHolder.getInstance().getListOfCoordsInProvince(province)) {
 			debugDrawChunk(tpCoord, province, worldName);
 		}
 	}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DynmapDisplayTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DynmapDisplayTask.java
@@ -19,7 +19,7 @@ public class DynmapDisplayTask extends BukkitRunnable {
 			} else {
 				jobRunning = true;
 			}
-			synchronized (TownyProvinces.MAP_CHANGE_LOCK) {
+			synchronized (TownyProvinces.DYNMAP_DISPLAY_LOCK) {
 				dynmapDisplayMapAction.executeAction(DynmapDisplayTaskController.getBordersRefreshRequested(), DynmapDisplayTaskController.getHomeBlocksRefreshRequested());
 			}
 		} finally {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
@@ -2,6 +2,7 @@ package io.github.townyadvanced.townyprovinces.jobs.land_validation;
 
 import com.palmergames.bukkit.towny.object.Translatable;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
+import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 import io.github.townyadvanced.townyprovinces.objects.Province;
@@ -39,6 +40,8 @@ public class LandValidationTaskController {
 			landValidationTask = null;
 			setLandValidationRequestsForAllProvinces(false);  //Clear all requests
 			landValidationJobStatus = LandValidationJobStatus.STOPPED;
+			TownyProvinces.info("Land Validation Task: Saving data");
+			DataHandlerUtil.saveAllData();
 			Messaging.sendGlobalMessage(Translatable.of("msg_land_validation_job_stopped"));
 		}
 	}
@@ -48,6 +51,8 @@ public class LandValidationTaskController {
 			landValidationTask.cancel();
 			landValidationTask = null;
 			landValidationJobStatus = LandValidationJobStatus.PAUSED;
+			TownyProvinces.info("Land Validation Task: Saving data");
+			DataHandlerUtil.saveAllData();
 			Messaging.sendGlobalMessage(Translatable.of("msg_land_validation_job_paused"));
 		}
 	}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
@@ -10,17 +10,17 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class LandvalidationTask extends BukkitRunnable {
 	
 	@Override
 	public void run() {
 		//Execute the land validation job
-		synchronized (TownyProvinces.MAP_CHANGE_LOCK) {
-			TownyProvinces.info("Land Validation Job Starting.");
-			executeLandValidation();
-		}
+		TownyProvinces.info("Land Validation Job Starting.");
+		executeLandValidation();
 	}
 	
 	/**
@@ -38,21 +38,21 @@ public class LandvalidationTask extends BukkitRunnable {
 	private void executeLandValidation() {
 		TownyProvinces.info("Now Running land validation job.");
 		double numProvincesProcessed = 0;
-		for(Province province : TownyProvincesDataHolder.getInstance().getProvincesSet()) {
+		Set<Province> copyOfProvincesSet = new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet());
+		for(Province province : copyOfProvincesSet) {
 			if(!province.isLandValidationRequested())
 				numProvincesProcessed++;  //Already processed
 		}
-		for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
+		for(Province province: copyOfProvincesSet) {
 			if (province.isLandValidationRequested()) {
 				boolean isSea = isProvinceMainlyOcean(province);
 				if(isSea != province.isSea()) {
 					province.setSea(isSea);
 				}
 				province.setLandValidationRequested(false);
-				province.saveData();
 				numProvincesProcessed++;
 			}
-			int percentCompletion = (int)((numProvincesProcessed / TownyProvincesDataHolder.getInstance().getProvincesSet().size()) * 100);
+			int percentCompletion = (int)((numProvincesProcessed / copyOfProvincesSet.size()) * 100);
 			TownyProvinces.info("Land Validation Job Progress: " + percentCompletion + "%");
 
 			//Handle any stop requests
@@ -74,7 +74,7 @@ public class LandvalidationTask extends BukkitRunnable {
 	}
 
 	private static boolean isProvinceMainlyOcean(Province province) {
-		List<TPCoord> coordsInProvince = province.getCoordsInProvince();
+		List<TPCoord> coordsInProvince = province.getListOfCoordsInProvince();
 		String worldName = TownyProvincesSettings.getWorldName();
 		World world = Bukkit.getWorld(worldName);
 		Biome biome;
@@ -84,13 +84,6 @@ public class LandvalidationTask extends BukkitRunnable {
 			int x = (coordToTest.getX() * TownyProvincesSettings.getChunkSideLength()) + 8;
 			int z = (coordToTest.getZ() * TownyProvincesSettings.getChunkSideLength()) + 8;
 			biome = world.getHighestBlockAt(x,z).getBiome();
-			System.gc();
-			try {
-				//Sleep as the above check is hard on processor
-				Thread.sleep(1500);
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e);
-			}
 			if(!biome.name().toLowerCase().contains("ocean") && !biome.name().toLowerCase().contains("beach")) {
 				return false;
 			}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -124,7 +124,7 @@ public class PaintRegionAction {
 		int minZ = TownyProvincesSettings.getTopLeftCornerLocation(regionName).getBlockZ() / TownyProvincesSettings.getChunkSideLength();
 		int maxZ  = TownyProvincesSettings.getBottomRightCornerLocation(regionName).getBlockZ() / TownyProvincesSettings.getChunkSideLength();
 		for(Province province: (new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet()))) {
-			List<TPCoord> coordsInProvince = province.getCoordsInProvince();
+			List<TPCoord> coordsInProvince = province.getListOfCoordsInProvince();
 			int numProvinceBlocksInSpecifiedArea = 0;
 			for (TPCoord coordInProvince : coordsInProvince) {
 				if (coordInProvince.getX() < minX)
@@ -514,7 +514,7 @@ public class PaintRegionAction {
 		TownyProvinces.info("Now Deleting Empty Provinces.");
 		Set<Province> provincesToDelete = new HashSet<>();
 		for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
-			if(province.getCoordsInProvince().size() == 0) {
+			if(province.getListOfCoordsInProvince().size() == 0) {
 				provincesToDelete.add(province);
 			}
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/RegenerateRegionTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/RegenerateRegionTask.java
@@ -42,13 +42,13 @@ public class RegenerateRegionTask extends BukkitRunnable {
 	public void run() {
 		try {
 			TownyProvinces.info("Regeneration Job Started");
-			TownyProvinces.info("Regeneration Job: Acquiring map change lock");
-			synchronized (TownyProvinces.MAP_CHANGE_LOCK) {
-				TownyProvinces.info("Regeneration Job: Map Change lock acquired");
+			TownyProvinces.info("Regeneration Job: Acquiring dynmap display lock");
+			synchronized (TownyProvinces.DYNMAP_DISPLAY_LOCK) {
+				TownyProvinces.info("Regeneration Job: Dynmap display lock acquired");
 				executeRegionRegenerationJob();
 			}
 		} finally {
-			TownyProvinces.info("Regeneration Job: Map Change lock released");
+			TownyProvinces.info("Regeneration Job: Dynmap display lock released");
 			RegenerateRegionTaskController.endTask();
 			TownyProvinces.info("Regeneration Job Completed");
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -185,7 +185,7 @@ public class TownyListener implements Listener {
 	private boolean doesProvinceContainTown(Province province) {
 		String worldName = TownyProvincesSettings.getWorldName();
 		WorldCoord worldCoord;
-		for(TPCoord coord: province.getCoordsInProvince()) {
+		for(TPCoord coord: province.getListOfCoordsInProvince()) {
 			worldCoord = new WorldCoord(worldName, coord.getX(), coord.getZ());
 			if(!TownyAPI.getInstance().isWilderness(worldCoord)) {
 				return true;

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
@@ -1,6 +1,5 @@
 package io.github.townyadvanced.townyprovinces.objects;
 
-import com.palmergames.bukkit.towny.object.Coord;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 
@@ -63,8 +62,8 @@ public class Province {
 		this.isSea = b;
 	}
 
-	public List<TPCoord> getCoordsInProvince() {
-		return TownyProvincesDataHolder.getInstance().getCoordsInProvince(this);
+	public List<TPCoord> getListOfCoordsInProvince() {
+		return TownyProvincesDataHolder.getInstance().getListOfCoordsInProvince(this);
 	}
 
 	public void saveData() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
@@ -110,7 +110,7 @@ public class FileUtil {
 				fileEntries.add("bottom_right_corner_location: 900,-630");
 				fileEntries.add("average_province_size: 20000");
 				fileEntries.add("minimum_start_distance_between_brushes: 16");
-				fileEntries.add("max_allowed_variance_between_ideal_and_actual_num_provinces: 0.1");
+				fileEntries.add("max_allowed_variance_between_ideal_and_actual_num_provinces: 0.2");
 				fileEntries.add("brush_square_radius_in_chunks: 2");
 				fileEntries.add("min_brush_move_amount_in_chunks: 1");
 				fileEntries.add("max_brush_move_amount_in_chunks: 2");


### PR DESCRIPTION
- Improved speed of land validation job
- Allowed job to run in parallel with other jobs (rather than doing a synch lock)
- Thanks a lot to user "NNYaKNpGms0eUVpiSdHx" ! , who guessed that the job was running slower than it needed to be

NOTE:
- This job does cause my server to fall many ticks behind.....however given that this job would usually be run before any players job, it might be ok.....lets wait for reports before taking action ....