### PR TITLE
Add metadata for existing signs when a travel plot is claimed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyProvinces</artifactId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <name>townyprovinces</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/BukkitListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/BukkitListener.java
@@ -6,7 +6,6 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.util.MathUtil;
-import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 import io.github.townyadvanced.townyprovinces.metadata.TownMetaDataController;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
@@ -112,7 +111,7 @@ public class BukkitListener implements Listener {
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK  
 				|| !event.hasBlock() 
 				|| event.getClickedBlock() == null
-				|| !FastTravelUtil.isFastTravelSign(event.getClickedBlock())) {
+				|| !FastTravelUtil.isFastTravelSign(event.getClickedBlock().getState())) {
 			return;
 		}
 		//Player clicked a fast travel sign. Lets see if we can move them
@@ -196,7 +195,7 @@ public class BukkitListener implements Listener {
 	@EventHandler(ignoreCancelled = true)
 	public void on(BlockBreakEvent event) {
 		if(!TownyAPI.getInstance().isWilderness(event.getBlock()) 
-				&& FastTravelUtil.isFastTravelSign(event.getBlock())) {
+				&& FastTravelUtil.isFastTravelSign(event.getBlock().getState())) {
 			TownBlock townBlock = TownyAPI.getInstance().getTownBlock(event.getBlock().getLocation());
 			if(townBlock == null)
 				return;

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -30,6 +30,7 @@ import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import io.github.townyadvanced.townyprovinces.util.BiomeUtil;
 import io.github.townyadvanced.townyprovinces.util.CustomPlotUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Biome;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -279,6 +280,9 @@ public class TownyListener implements Listener {
 				if(newType.equalsIgnoreCase("port")) {
 					TownMetaDataController.setPortCoord(town, eventWorldCoord);
 					town.save();
+					Bukkit.getScheduler().runTask(
+						TownyProvinces.getPlugin(),
+						() -> TownMetaDataController.addExistingSignsAtPort(town, eventWorldCoord));
 				}
 			} else {
 				//If this is a removal, remove metadata
@@ -297,6 +301,9 @@ public class TownyListener implements Listener {
 				if (newType.equalsIgnoreCase("jump-node")) {
 					TownMetaDataController.setJumpNodeCoord(town, eventWorldCoord);
 					town.save();
+					Bukkit.getScheduler().runTask(
+						TownyProvinces.getPlugin(), 
+						() -> TownMetaDataController.addExistingSignsAtJumpNode(town, eventWorldCoord));
 				}
 			} else {
 				//If this is a removal, remove metadata

--- a/src/main/java/io/github/townyadvanced/townyprovinces/metadata/TownMetaDataController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/metadata/TownMetaDataController.java
@@ -5,14 +5,22 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
+import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+import io.github.townyadvanced.townyprovinces.util.FastTravelUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class TownMetaDataController {
 	
@@ -262,6 +270,32 @@ public class TownMetaDataController {
 		removePortSigns(town);
 	}
 
+	public static void addExistingSignsAtPort(Town town, WorldCoord eventWorldCoord) {
+		addExistingSignsAtTravelPlot(town, eventWorldCoord, portSigns, "townyprovinces_portSigns");
+	}
+
+	public static void addExistingSignsAtJumpNode(Town town, WorldCoord eventWorldCoord) {
+		addExistingSignsAtTravelPlot(town, eventWorldCoord, jumpNodeSigns, "townyprovinces_jumpNodeSigns");
+	}
+
+	private static void addExistingSignsAtTravelPlot(Town town, WorldCoord eventWorldCoord, StringDataField metadataField, String metadataFieldName) {
+		Set<BlockState> existingSignBlockStates = new HashSet<>();
+		int x = (eventWorldCoord.getX());
+		int z = (eventWorldCoord.getZ());
+		Chunk chunk =  eventWorldCoord.getBukkitWorld().getChunkAt(x,z);
+		for(BlockState blockState: chunk.getTileEntities()) {
+			if(blockState instanceof Sign && FastTravelUtil.isFastTravelSign(blockState)) {
+				existingSignBlockStates.add(blockState);
+			}
+		}
+		String destinationTownName;
+		for(BlockState existingSignBlockState: existingSignBlockStates) {
+			destinationTownName = ((Sign)existingSignBlockState).getLine(2);
+			addTravelPlotSign(town, existingSignBlockState.getBlock(), destinationTownName, metadataField, metadataFieldName);
+		}
+		town.save();
+	}
+	
 	///////////////////////////////////////////////
 
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/util/FastTravelUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/util/FastTravelUtil.java
@@ -1,12 +1,13 @@
 package io.github.townyadvanced.townyprovinces.util;
 
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 
 public class FastTravelUtil {
 
-	public static boolean isFastTravelSign(Block block) {
-		return block.getState() instanceof Sign
-			&& (((Sign) block.getState()).getLine(0).trim().equals(">>>"));
+	public static boolean isFastTravelSign(BlockState blockState) {
+		return blockState instanceof Sign
+			&& (((Sign) blockState).getLine(0).trim().equals(">>>"));
 	}
 }


### PR DESCRIPTION
- As per description
- This is useful if for example, a player unclaims a port containing FT signs, then re-claims it and tries to turn it back into a port.
- Before this PR, the FT signs on such a plot would not work on the return journey, which was messy.