### PR TITLE
River ports

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -247,13 +247,15 @@ public class TownyListener implements Listener {
 				event.setCancelled(true);
 				event.setCancelMessage(Translatable.of("msg_err_cannot_add_a_second_port").translate(Locale.ROOT));
 			} else {
-				//Can only create port in ocean biome
+				//Can only create port in non-frozen water biome
 				Coord coord = event.getTownBlock().getCoord();
 				TPCoord tpCoord = new TPFinalCoord(coord.getX(), coord.getZ());
 				Biome biome = BiomeUtil.lookupBiome(tpCoord, event.getTownBlock().getWorld().getBukkitWorld());
-				if(!biome.name().toLowerCase().contains("ocean") 
-						&& !biome.name().toLowerCase().contains("beach")
-						&& !biome.name().toLowerCase().contains("river")) {
+				boolean isWaterBiome = biome.name().toLowerCase().contains("ocean")
+						|| biome.name().toLowerCase().contains("beach")
+						|| biome.name().toLowerCase().contains("river");
+				boolean isFrozen = biome.name().toLowerCase().contains("frozen");
+				if(!isWaterBiome || isFrozen) {
 					event.setCancelled(true);
 					event.setCancelMessage(Translatable.of("msg_err_ports_can_only_be_created_in_ocean_biomes").translate(Locale.ROOT));
 				}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -247,15 +247,14 @@ public class TownyListener implements Listener {
 				event.setCancelled(true);
 				event.setCancelMessage(Translatable.of("msg_err_cannot_add_a_second_port").translate(Locale.ROOT));
 			} else {
-				//Can only create port in non-frozen water biome
+				//Can only create port in water biome
 				Coord coord = event.getTownBlock().getCoord();
 				TPCoord tpCoord = new TPFinalCoord(coord.getX(), coord.getZ());
 				Biome biome = BiomeUtil.lookupBiome(tpCoord, event.getTownBlock().getWorld().getBukkitWorld());
 				boolean isWaterBiome = biome.name().toLowerCase().contains("ocean")
 						|| biome.name().toLowerCase().contains("beach")
 						|| biome.name().toLowerCase().contains("river");
-				//boolean isFrozen = biome.name().toLowerCase().contains("frozen");
-				if(!isWaterBiome) { // || isFrozen)
+				if(!isWaterBiome) {
 					event.setCancelled(true);
 					event.setCancelMessage(Translatable.of("msg_err_ports_can_only_be_created_in_ocean_biomes").translate(Locale.ROOT));
 				}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -251,7 +251,9 @@ public class TownyListener implements Listener {
 				Coord coord = event.getTownBlock().getCoord();
 				TPCoord tpCoord = new TPFinalCoord(coord.getX(), coord.getZ());
 				Biome biome = BiomeUtil.lookupBiome(tpCoord, event.getTownBlock().getWorld().getBukkitWorld());
-				if(!biome.name().toLowerCase().contains("ocean") && !biome.name().toLowerCase().contains("beach")) {
+				if(!biome.name().toLowerCase().contains("ocean") 
+						&& !biome.name().toLowerCase().contains("beach")
+						&& !biome.name().toLowerCase().contains("river")) {
 					event.setCancelled(true);
 					event.setCancelMessage(Translatable.of("msg_err_ports_can_only_be_created_in_ocean_biomes").translate(Locale.ROOT));
 				}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -254,8 +254,8 @@ public class TownyListener implements Listener {
 				boolean isWaterBiome = biome.name().toLowerCase().contains("ocean")
 						|| biome.name().toLowerCase().contains("beach")
 						|| biome.name().toLowerCase().contains("river");
-				boolean isFrozen = biome.name().toLowerCase().contains("frozen");
-				if(!isWaterBiome || isFrozen) {
+				//boolean isFrozen = biome.name().toLowerCase().contains("frozen");
+				if(!isWaterBiome) { // || isFrozen)
 					event.setCancelled(true);
 					event.setCancelMessage(Translatable.of("msg_err_ports_can_only_be_created_in_ocean_biomes").translate(Locale.ROOT));
 				}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -108,7 +108,7 @@ dynmap_layer_label_borders: "Borders"
 
 msg_err_cannot_add_a_second_jump_node: "&cTowns cannot have more than one Jump-Node."
 msg_err_cannot_add_a_second_port: "&cTowns cannot have more than one Port."
-msg_err_ports_can_only_be_created_in_ocean_biomes: "&cPorts can only be created in Ocean or Beach biomes."
+msg_err_ports_can_only_be_created_in_ocean_biomes: "&cPorts can only be created on Ocean, Beach, or River biomes."
 #msg_err_cannot_create_fast_travel_signs_except_in_travel_plots:  "&cFast-Travel-Signs can only be placed in Home-Blocks, Outposts, Ports, and Jump-Nodes."
 msg_err_cannot_create_fast_travel_signs_except_in_travel_plots:  "&cFast-Travel Signs can only be placed in Jump-Nodes or ports."
 msg_err_cannot_create_fast_travel_sign_bad_town_data:  "&cCannot create Fast-Travel Sign, because there was a problem with the data of the town or townblock."


### PR DESCRIPTION
- With current TP code, inland cities on rivers get no fast-travel advantage
- This is very not historically accurate. In ancient history, civilisations like Egypt and Sumer did well precisely because most of their towns were easily accessibly by port.
- This PR corrects the situation with a simple change: You can now place a port on a river biome