### PR TITLE
Set town costs to be per-chunk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyProvinces</artifactId>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
   <name>townyprovinces</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
@@ -88,16 +88,16 @@ DataHandlerUtil {
 		TPCoord homeBlock = unpackCoord(fileEntries.get("home_block"));
 		boolean isSea = Boolean.parseBoolean(fileEntries.get("is_sea"));
 		boolean isLandValidationRequested = false; 
-		int newTownCost = 0;
-		int upkeepTownCost = 0;
+		double newTownCost = 0;
+		double upkeepTownCost = 0;
 		if(fileEntries.containsKey("is_land_validation_requested")) {
 			isLandValidationRequested = Boolean.parseBoolean(fileEntries.get("is_land_validation_requested"));
 		}
 		if(fileEntries.containsKey("new_town_cost")) {
-			newTownCost = Integer.parseInt(fileEntries.get("new_town_cost"));
+			newTownCost = Double.parseDouble(fileEntries.get("new_town_cost"));
 		}
 		if(fileEntries.containsKey("upkeep_town_cost")) {
-			upkeepTownCost = Integer.parseInt(fileEntries.get("upkeep_town_cost"));
+			upkeepTownCost = Double.parseDouble(fileEntries.get("upkeep_town_cost"));
 		}
 		//Create province
 		Province province = new Province(homeBlock, isSea, isLandValidationRequested, newTownCost, upkeepTownCost);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
@@ -94,10 +94,10 @@ DataHandlerUtil {
 			isLandValidationRequested = Boolean.parseBoolean(fileEntries.get("is_land_validation_requested"));
 		}
 		if(fileEntries.containsKey("new_town_cost")) {
-			newTownCost = Double.parseDouble(fileEntries.get("new_town_cost"));
+			newTownCost = Double.parseDouble(fileEntries.get("new_town_cost_per_chunk"));
 		}
 		if(fileEntries.containsKey("upkeep_town_cost")) {
-			upkeepTownCost = Double.parseDouble(fileEntries.get("upkeep_town_cost"));
+			upkeepTownCost = Double.parseDouble(fileEntries.get("upkeep_town_cost_per_chunk"));
 		}
 		//Create province
 		Province province = new Province(homeBlock, isSea, isLandValidationRequested, newTownCost, upkeepTownCost);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -108,12 +108,6 @@ public class PaintRegionAction {
 			TownyProvinces.info("Problem deleting empty provinces");
 			return false;
 		}
-		
-		//Recalculate Prices of all provinces
-		if(!recalculateProvincePrices()) {
-			TownyProvinces.info("Recalculating province prices");
-			return false;
-		}
 
 		TownyProvinces.info("Finished Painting Provinces In Region: " + regionName);
 		return true;
@@ -487,14 +481,5 @@ public class PaintRegionAction {
 		TownyProvinces.info("Empty Provinces Deleted.");
 		return true;
 	}
-
-	private boolean recalculateProvincePrices() {
-		for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
-			int numChunks = province.getListOfCoordsInProvince().size();
-			province.setNewTownCost(numChunks * newTownCostPerChunk);
-			province.setUpkeepTownCost(numChunks * upkeepTownCostPerChunk);
-		}
-		return true;
-	}
-
+	
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/RegenerateRegionTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/RegenerateRegionTask.java
@@ -1,10 +1,12 @@
 package io.github.townyadvanced.townyprovinces.jobs.province_generation;
 
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.Translatable;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.jobs.dynmap_display.DynmapDisplayTaskController;
+import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
@@ -82,6 +84,8 @@ public class RegenerateRegionTask extends BukkitRunnable {
 			TownyProvinces.info("Problem Painting Regions");
 			return;
 		}
+		//Recalculated all prices
+		recalculateProvincePrices();
 		//Save data and request full dynmap refresh
 		DataHandlerUtil.saveAllData();
 		DynmapDisplayTaskController.requestFullMapRefresh();
@@ -92,6 +96,22 @@ public class RegenerateRegionTask extends BukkitRunnable {
 			TownyProvinces.info(Translatable.of("msg_successfully_regenerated_one_regions", regionName).translate(Locale.ROOT));
 		}
 		TownyProvinces.info("Region regeneration Job Complete"); //TODO - maybe global message?
+	}
+
+	
+	private void recalculateProvincePrices() {
+		TownyProvinces.info("Recalculating province prices");
+		for (String regionName: TownyProvincesSettings.getOrderedRegionNames()) {
+			double newTownCostPerChunk = TownyProvincesSettings.getNewTownCostPerChunk(regionName);
+			double upkeepTownCostPerChunk = TownyProvincesSettings.getUpkeepTownCostPerChunk(regionName);
+			for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
+				if (TownyProvincesSettings.isProvinceInRegion(province, regionName)) {
+					province.setNewTownCost(newTownCostPerChunk * province.getListOfCoordsInProvince().size());
+					province.setUpkeepTownCost(upkeepTownCostPerChunk * province.getListOfCoordsInProvince().size());
+				}
+			}
+		}
+		TownyProvinces.info("Province Prices recalculated");
 	}
 	
 	public boolean paintAllRegions() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -5,7 +5,6 @@ import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.PlotChangeTypeEvent;
 import com.palmergames.bukkit.towny.event.PlotPreChangeTypeEvent;
-import com.palmergames.bukkit.towny.event.PreDeleteTownEvent;
 import com.palmergames.bukkit.towny.event.PreNewTownEvent;
 import com.palmergames.bukkit.towny.event.TownBlockTypeRegisterEvent;
 import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
@@ -168,7 +167,7 @@ public class TownyListener implements Listener {
 	}
 
 	@EventHandler(ignoreCancelled = true)
-	public void onTownClaimAttempt(TownPreClaimEvent event) {
+	public void onTownPreClaimAttempt(TownPreClaimEvent event) {
 		if (!TownyProvincesSettings.isTownyProvincesEnabled()) {
 			return;
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
@@ -9,8 +9,8 @@ import java.util.Set;
 public class Province {
 	
 	private final TPCoord homeBlock;
-	private int newTownCost;
-	private int upkeepTownCost;
+	private double newTownCost;
+	private double upkeepTownCost;
 	private boolean isSea;
 	private final String id; //convenience variable. In memory only. Used for dynmap and file operations
 	private boolean landValidationRequested;
@@ -21,7 +21,7 @@ public class Province {
 		return homeBlock.equals(((Province)object).getHomeBlock());
 	}
 	
-	public Province(TPCoord homeBlock, boolean isSea, boolean landValidationRequested, int newTownCost, int upkeepTownCost) {
+	public Province(TPCoord homeBlock, boolean isSea, boolean landValidationRequested, double newTownCost, double upkeepTownCost) {
 		this.homeBlock = homeBlock;
 		this.isSea = isSea;
 		this.newTownCost = newTownCost;
@@ -38,19 +38,19 @@ public class Province {
 		return homeBlock;
 	}
 	
-	public void setNewTownCost(int i) {
-		this.newTownCost = i;
+	public void setNewTownCost(double d) {
+		this.newTownCost = d;
 	}
 
-	public void setUpkeepTownCost(int i) {
-		this.upkeepTownCost = i;
+	public void setUpkeepTownCost(double d) {
+		this.upkeepTownCost = d;
 	}
 
-	public int getNewTownCost() {
+	public double getNewTownCost() {
 		return newTownCost;
 	}
 
-	public int getUpkeepTownCost() {
+	public double getUpkeepTownCost() {
 		return upkeepTownCost;
 	}
 	

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -149,16 +149,16 @@ public class TownyProvincesSettings {
 		return (int)((Math.sqrt(averageProvinceSize)) / 2);
 	}
 
-	public static int getNewTownCost(String regionName) {
+	public static double getNewTownCostPerChunk(String regionName) {
 		Map<String,String> regionDefinitions = TownyProvincesSettings.getRegionDefinitions(regionName);
-		String intString = regionDefinitions.get("new_town_cost");
-		return Integer.parseInt(intString);
+		String intString = regionDefinitions.get("new_town_cost_per_chunk");
+		return Double.parseDouble(intString);
 	}
 
-	public static int getUpkeepTownCost(String regionName) {
+	public static double getUpkeepTownCostPerChunk(String regionName) {
 		Map<String,String> regionDefinitions = TownyProvincesSettings.getRegionDefinitions(regionName);
-		String intString = regionDefinitions.get("upkeep_town_cost");
-		return Integer.parseInt(intString);
+		String intString = regionDefinitions.get("upkeep_town_cost_per_chunk");
+		return Double.parseDouble(intString);
 	}
 	
 	public static int getLandProvinceBorderWeight() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
@@ -94,7 +94,7 @@ public class FileUtil {
 				fileEntries.add("brush_min_move_as_percentage_of_brush_max_move: 50");
 				fileEntries.add("max_brush_moves: 100");
 				fileEntries.add("new_town_cost_per_chunk: 0.8");
-				fileEntries.add("upkeep_town_cost_per_chunk: 0.04");
+				fileEntries.add("upkeep_town_cost_per_chunk: 0.08");
 				String folderPath = TownyProvinces.getPlugin().getDataFolder().toPath().resolve(FileUtil.REGION_DEFINITIONS_FOLDER_PATH).toString();
 				String filePath = folderPath + "/" + fileName;
 				saveListIntoFile(fileEntries, filePath);
@@ -111,7 +111,7 @@ public class FileUtil {
 				fileEntries.add("brush_min_move_as_percentage_of_brush_max_move: 50");
 				fileEntries.add("max_brush_moves: 100");
 				fileEntries.add("new_town_cost_per_chunk: 7.2");
-				fileEntries.add("upkeep_town_cost_per_chunk: 0.36");
+				fileEntries.add("upkeep_town_cost_per_chunk: 0.72");
 				folderPath = TownyProvinces.getPlugin().getDataFolder().toPath().resolve(FileUtil.REGION_DEFINITIONS_FOLDER_PATH).toString();
 				filePath = folderPath + "/" + fileName;
 				saveListIntoFile(fileEntries, filePath);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
@@ -93,8 +93,8 @@ public class FileUtil {
 				fileEntries.add("brush_max_move_as_percentage_of_brush_square_radius: 50");
 				fileEntries.add("brush_min_move_as_percentage_of_brush_max_move: 50");
 				fileEntries.add("max_brush_moves: 100");
-				fileEntries.add("new_town_cost: 250");
-				fileEntries.add("upkeep_town_cost: 10");
+				fileEntries.add("new_town_cost_per_chunk: 0.8");
+				fileEntries.add("upkeep_town_cost_per_chunk: 0.04");
 				String folderPath = TownyProvinces.getPlugin().getDataFolder().toPath().resolve(FileUtil.REGION_DEFINITIONS_FOLDER_PATH).toString();
 				String filePath = folderPath + "/" + fileName;
 				saveListIntoFile(fileEntries, filePath);
@@ -110,8 +110,8 @@ public class FileUtil {
 				fileEntries.add("brush_max_move_as_percentage_of_brush_square_radius: 50");
 				fileEntries.add("brush_min_move_as_percentage_of_brush_max_move: 50");
 				fileEntries.add("max_brush_moves: 100");
-				fileEntries.add("new_town_cost: 300");
-				fileEntries.add("upkeep_town_cost: 12");
+				fileEntries.add("new_town_cost_per_chunk: 7.2");
+				fileEntries.add("upkeep_town_cost_per_chunk: 0.36");
 				folderPath = TownyProvinces.getPlugin().getDataFolder().toPath().resolve(FileUtil.REGION_DEFINITIONS_FOLDER_PATH).toString();
 				filePath = folderPath + "/" + fileName;
 				saveListIntoFile(fileEntries, filePath);

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -54,10 +54,10 @@ msg_successfully_regenerated_one_regions: "&bSuccessfully regenerated region: %s
 # Set town costs
 
 msg_err_value_must_be_and_integer: "&cThe given value must be an integer."
-msg_new_town_cost_set_for_all_regions: "&bNew-Town-Cost set for all regions, to: %s"
-msg_new_town_cost_set_for_one_region: "&bNew-Town-Cost set for region %s, to: %s"
-msg_upkeep_town_cost_set_for_all_regions: "&bUpkeep-Town-Cost set for all regions, to: %s"
-msg_upkeep_town_cost_set_for_one_region: "&bUpkeep-Town-Cost set for region %s, to: %s"
+msg_new_town_cost_set_for_all_regions: "&bNew-Town-Cost-Per-Chunk set for all regions, to: %s"
+msg_new_town_cost_set_for_one_region: "&bNew-Town-Cost-Per-Chunk set for region %s, to: %s"
+msg_upkeep_town_cost_set_for_all_regions: "&bUpkeep-Town-Cost-Per-Chunk set for all regions, to: %s"
+msg_upkeep_town_cost_set_for_one_region: "&bUpkeep-Town-Cost-Per-Chunk set for region %s, to: %s"
 
 # Land validation job
 


### PR DESCRIPTION
- Requested by Valoria
- Since province sizes are often highly varied, it may seem fairer to players if their town costs depend on the size of the province
- This PR does just that, so that both the generation and commands go by the number of chunks in the province
- Note that anyone with existing region def files will need to update the 2 costs fields to be:
  - new_town_cost_per_chunk
  - upkeep_town_cost_per_chunk