### PR TITLE
Outpost integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyProvinces</artifactId>
-  <version>1.12.0</version>
+  <version>1.13.0</version>
   <name>townyprovinces</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/commands/TownyProvincesAdminCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/commands/TownyProvincesAdminCommand.java
@@ -47,7 +47,7 @@ public class TownyProvincesAdminCommand implements TabExecutor {
 				if (args.length == 2) {
 					return NameUtil.filterByStart(adminTabCompletesProvince, args[1]);
 				} else if (args.length == 3) {
-					return NameUtil.filterByStart(adminTabCompletesProvinceSetType, args[1]);
+					return NameUtil.filterByStart(adminTabCompletesProvinceSetType, args[2]);
 				}
 				break;
 			case "region":
@@ -216,7 +216,7 @@ public class TownyProvincesAdminCommand implements TabExecutor {
 		try {
 			ProvinceType provinceType;
 			if(args[1].equalsIgnoreCase("civilized")) {
-				provinceType = ProvinceType.CIVILISED;
+				provinceType = ProvinceType.CIVILIZED;
 			} else if(args[1].equalsIgnoreCase("sea")) {
 				provinceType = ProvinceType.SEA;
 			} else if(args[1].equalsIgnoreCase("wasteland")) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/commands/TownyProvincesAdminCommand.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/commands/TownyProvincesAdminCommand.java
@@ -249,7 +249,7 @@ public class TownyProvincesAdminCommand implements TabExecutor {
 		int x = Integer.parseInt(locationAsArray[0]);
 		int y = Integer.parseInt(locationAsArray[1]);
 		Coord coord = Coord.parseCoord(x,y);
-		Province province = TownyProvincesDataHolder.getInstance().getProvinceAt(coord.getX(), coord.getZ());
+		Province province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(coord.getX(), coord.getZ());
 		//Validate action
 		if(province == null) {
 			Messaging.sendMsg(sender, Translatable.of("msg_err_invalid_province_location"));

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
@@ -107,7 +107,7 @@ DataHandlerUtil {
 			if (Boolean.parseBoolean(fileEntries.get("is_sea"))) {
 				province.setType(ProvinceType.SEA);
 			} else {
-				province.setType(ProvinceType.CIVILISED);
+				province.setType(ProvinceType.CIVILIZED);
 			}
 		}
 		if(fileEntries.containsKey("type")) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/DataHandlerUtil.java
@@ -3,6 +3,7 @@ package io.github.townyadvanced.townyprovinces.data;
 import com.palmergames.util.FileMgmt;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.objects.ProvinceType;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
 import io.github.townyadvanced.townyprovinces.util.FileUtil;
@@ -46,7 +47,7 @@ DataHandlerUtil {
 		String fileName = folderPath + "/" + province.getId() + ".yml";
 		Map<String, String> fileEntries = new HashMap<>();
 		fileEntries.put("home_block", "" + province.getHomeBlock().getX() + "," + province.getHomeBlock().getZ());
-		fileEntries.put("is_sea", "" + province.isSea());
+		fileEntries.put("type", "" + province.getType().name());
 		fileEntries.put("is_land_validation_requested", "" + province.isLandValidationRequested());
 		fileEntries.put("new_town_cost", "" + province.getNewTownCost());
 		fileEntries.put("upkeep_town_cost", "" + province.getUpkeepTownCost());
@@ -103,7 +104,14 @@ DataHandlerUtil {
 			province.setLandValidationRequested(Boolean.parseBoolean(fileEntries.get("is_land_validation_requested")));
 		}
 		if(fileEntries.containsKey("is_sea")) {
-			province.setSea(Boolean.parseBoolean(fileEntries.get("is_sea")));
+			if (Boolean.parseBoolean(fileEntries.get("is_sea"))) {
+				province.setType(ProvinceType.SEA);
+			} else {
+				province.setType(ProvinceType.CIVILISED);
+			}
+		}
+		if(fileEntries.containsKey("type")) {
+			province.setType(ProvinceType.parseProvinceType(fileEntries.get("type")));
 		}
 		if(fileEntries.containsKey("estimated_proportion_of_good_land")) {
 			province.setEstimatedProportionOfGoodLand(Double.parseDouble(fileEntries.get("estimated_proportion_of_good_land")));

--- a/src/main/java/io/github/townyadvanced/townyprovinces/data/TownyProvincesDataHolder.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/data/TownyProvincesDataHolder.java
@@ -1,6 +1,9 @@
 package io.github.townyadvanced.townyprovinces.data;
 
 import com.palmergames.bukkit.towny.object.Coord;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.WorldCoord;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
@@ -8,6 +11,7 @@ import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,11 +93,19 @@ public class TownyProvincesDataHolder {
 		return coordProvinceMap;
 	}
 	
-	public Province getProvinceAt(int x, int z) {
+	public @Nullable Province getProvinceAtCoord(int x, int z) {
 		searchCoord.setValues(x,z);
 		return coordProvinceMap.get(searchCoord);
 	}
 
+	public @Nullable Province getProvinceAtWorldCoord(WorldCoord worldCoord) {
+		if(!TownyProvincesSettings.getWorld().equals(worldCoord.getBukkitWorld())) {
+			return null;
+		}
+		searchCoord.setValues(worldCoord.getX(),worldCoord.getZ());
+		return coordProvinceMap.get(searchCoord);
+	}
+	
 	public Set<Province> getProvincesSet() {
 		return provincesSet;
 	}
@@ -226,6 +238,18 @@ public class TownyProvincesDataHolder {
 					&& homeBlock.getZ() >= topLeftCoord.getZ()
 					&& homeBlock.getZ() <= bottomRightCoord.getZ()) {
 				result.add(province);
+			}
+		}
+		return result;
+	}
+
+	public int getNumTownBlocksInProvince(Town town, Province province) {
+		int result = 0;
+		Province provinceAtWorldCoord;
+		for(TownBlock townBlock: town.getTownBlocks()) {
+			provinceAtWorldCoord = getProvinceAtWorldCoord(townBlock.getWorldCoord());
+			if(provinceAtWorldCoord != null && provinceAtWorldCoord.equals(province)) {
+				result++;	
 			}
 		}
 		return result;

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
@@ -300,7 +300,7 @@ public class DisplayProvincesOnDynmapAction {
 		Set<TPCoord> adjacentCoords = RegenerateRegionTask.findAllAdjacentCoords(borderCoordBeingPulled);
 		Province adjacenProvince;
 		for(TPCoord adjacentCoord: adjacentCoords) {
-			adjacenProvince = TownyProvincesDataHolder.getInstance().getProvinceAt(adjacentCoord.getX(), adjacentCoord.getZ());
+			adjacenProvince = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(adjacentCoord.getX(), adjacentCoord.getZ());
 			if(adjacenProvince != null && adjacenProvince.equals(provinceDoingThePulling)) {
 				pullStrengthX += (adjacentCoord.getX() - borderCoordBeingPulled.getX());
 				pullStrengthZ += (adjacentCoord.getZ() - borderCoordBeingPulled.getZ());

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/dynmap_display/DisplayProvincesOnDynmapAction.java
@@ -100,14 +100,8 @@ public class DisplayProvincesOnDynmapAction {
 				String homeBlockMarkerId = "province_homeblock_" + homeBlock.getX() + "-" + homeBlock.getZ();
 				Marker homeBlockMarker = homeBlocksMarkerSet.findMarker(homeBlockMarkerId);
 
-				if(province.isSea()) {
-					//This is sea. If the marker is there, we need to remove it
-					if(homeBlockMarker == null)
-						continue;
-					homeBlockMarker.deleteMarker();
-					return;
-				} else {
-					//This is land If the marker is not there, we need to add it
+				if(province.getType().canNewTownsBeCreated()) {
+					//Province is settle-able. If the marker is not there, we need to add it
 					if(homeBlockMarker != null)
 						continue;
 					int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
@@ -123,12 +117,18 @@ public class DisplayProvincesOnDynmapAction {
 					} else {
 						markerLabel = "";
 					}
-					
+
 					homeBlockMarker = homeBlocksMarkerSet.createMarker(
 						homeBlockMarkerId, markerLabel, TownyProvincesSettings.getWorldName(),
 						realHomeBlockX, 64, realHomeBlockZ,
 						homeBlockIcon, true);
 					homeBlockMarker.setDescription(markerLabel);
+				} else {
+					//Province is not settle-able. If the marker is there, we need to remove it
+					if(homeBlockMarker == null)
+						continue;
+					homeBlockMarker.deleteMarker();
+					return;
 				}
 			} catch (Exception ex) {
 				TownyProvinces.severe("Problem adding homeblock marker");
@@ -169,17 +169,10 @@ public class DisplayProvincesOnDynmapAction {
 				}
 			}
 		} else {
-			//Re-evaluate colour 
-			if (province.isSea()) {
-				if (polyLineMarker.getLineColor() != TownyProvincesSettings.getSeaProvinceBorderColour()) {
-					//Change colour of marker
-					polyLineMarker.setLineStyle(TownyProvincesSettings.getSeaProvinceBorderWeight(), TownyProvincesSettings.getSeaProvinceBorderOpacity(), TownyProvincesSettings.getSeaProvinceBorderColour());
-				}
-			} else {
-				if (polyLineMarker.getLineColor() != TownyProvincesSettings.getLandProvinceBorderColour()) {
-					//Change colour of marker
-					polyLineMarker.setLineStyle(TownyProvincesSettings.getLandProvinceBorderWeight(), TownyProvincesSettings.getLandProvinceBorderOpacity(), TownyProvincesSettings.getLandProvinceBorderColour());
-				}
+			//Re-evaluate colour
+			if (polyLineMarker.getLineColor() != province.getType().getBorderColour()) {
+				//Change colour of marker
+				polyLineMarker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
 			}
 		} 
 	}
@@ -235,13 +228,10 @@ public class DisplayProvincesOnDynmapAction {
 
 	private void drawBorderLine(List<TPCoord> drawableLineOfBorderCoords, Province province, String markerId) {
 		String worldName = TownyProvincesSettings.getWorldName();
-		int landBorderColour = TownyProvincesSettings.getLandProvinceBorderColour();
-		int landBorderWeight = TownyProvincesSettings.getLandProvinceBorderWeight();
-		double landBorderOpacity = TownyProvincesSettings.getLandProvinceBorderOpacity();
-		int seaProvinceBorderColour = TownyProvincesSettings.getSeaProvinceBorderColour();
-		int seaProvinceBorderWeight = TownyProvincesSettings.getSeaProvinceBorderWeight();
-		double seaProvinceBorderOpacity = TownyProvincesSettings.getSeaProvinceBorderOpacity();
-
+		int borderColour = province.getType().getBorderColour();
+		int borderWeight = province.getType().getBorderWeight();
+		double borderOpacity = province.getType().getBorderOpacity();
+		
 		double[] xPoints = new double[drawableLineOfBorderCoords.size()];
 		double[] zPoints = new double[drawableLineOfBorderCoords.size()];
 		for (int i = 0; i < drawableLineOfBorderCoords.size(); i++) {
@@ -301,11 +291,7 @@ public class DisplayProvincesOnDynmapAction {
 			xPoints, zPoints, zPoints, unknown2);
 		
 		//Set colour
-		if (province.isSea()) {
-			polyLineMarker.setLineStyle(seaProvinceBorderWeight, seaProvinceBorderOpacity, seaProvinceBorderColour);
-		} else {
-			polyLineMarker.setLineStyle(landBorderWeight, landBorderOpacity, landBorderColour);
-		}
+		polyLineMarker.setLineStyle(borderWeight, borderOpacity, borderColour);
 	}
 	
 	private void calculatePullStrengthFromNearbyProvince(TPCoord borderCoordBeingPulled, Province provinceDoingThePulling, TPFreeCoord freeCoord) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
@@ -1,10 +1,10 @@
 package io.github.townyadvanced.townyprovinces.jobs.land_validation;
 
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
-import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.jobs.dynmap_display.DynmapDisplayTaskController;
 import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.objects.ProvinceType;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import io.github.townyadvanced.townyprovinces.util.BiomeUtil;
@@ -142,8 +142,14 @@ public class LandvalidationTask extends BukkitRunnable {
 			}
 		}
 		
-		//Set land sea
-		province.setSea(water == totalChunksToScan);
+		//Set type
+		if(water == totalChunksToScan) {
+			province.setType(ProvinceType.SEA);
+		} else if (goodLand == 0) {
+			province.setType(ProvinceType.WASTELAND);
+		} else {
+			province.setType(ProvinceType.CIVILISED);
+		}
 			
 		//Set proportions
 		province.setEstimatedProportionOfGoodLand(goodLand / totalChunksToScan);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandvalidationTask.java
@@ -148,7 +148,7 @@ public class LandvalidationTask extends BukkitRunnable {
 		} else if (goodLand == 0) {
 			province.setType(ProvinceType.WASTELAND);
 		} else {
-			province.setType(ProvinceType.CIVILISED);
+			province.setType(ProvinceType.CIVILIZED);
 		}
 			
 		//Set proportions

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -319,7 +319,7 @@ public class PaintRegionAction {
 		Province province;
 		for(int x = brushMinCoordX -1; x <= (brushMaxCoordX +1); x++) {
 			for(int z = brushMinCoordZ -1; z <= (brushMaxCoordZ +1); z++) {
-				province = TownyProvincesDataHolder.getInstance().getProvinceAt(x,z);
+				province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(x,z);
 				if(province != null && province != provinceBeingPainted) {
 					return false;
 				}
@@ -439,7 +439,7 @@ public class PaintRegionAction {
 		int[] x = new int[]{0,0,1,-1};
 		int[] z = new int[]{-1,1,0,0};
 		for(int i = 0; i < 4; i++) {
-			province = TownyProvincesDataHolder.getInstance().getProvinceAt(unclaimedCoord.getX() + x[i], unclaimedCoord.getZ() + z[i]);
+			province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(unclaimedCoord.getX() + x[i], unclaimedCoord.getZ() + z[i]);
 			if (province != null) {
 				if(result == null) {
 					result = province;
@@ -456,7 +456,7 @@ public class PaintRegionAction {
 		x = new int[]{-1,1,1,-1};
 		z = new int[]{-1,-1,1,1};
 		for(int i = 0; i < 4; i++) {
-			province = TownyProvincesDataHolder.getInstance().getProvinceAt(unclaimedCoord.getX() + x[i], unclaimedCoord.getZ() + z[i]);
+			province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(unclaimedCoord.getX() + x[i], unclaimedCoord.getZ() + z[i]);
 			if (province != null && province != result) {
 				return null; //2 different adjacent provinces found. Return null, as this chunk will be a border.
 			}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -189,13 +189,13 @@ public class TownyListener implements Listener {
 		Province provinceAtClaimLocation = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(event.getTownBlock().getX(), event.getTownBlock().getZ());
 		if (provinceAtClaimLocation == null) {
 			event.setCancelled(true);
-			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + " " + Translatable.of("msg_err_cannot_claim_land_on_province_border").translate(Locale.ROOT));
+			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + Translatable.of("msg_err_cannot_claim_land_on_province_border").translate(Locale.ROOT));
 			return;
 		}
 		//Can't claim without homeblock
 		if(!event.getTown().hasHomeBlock()) {
 			event.setCancelled(true);
-			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + " " + Translatable.of("msg_err_cannot_claim_land_without_homeblock").translate(Locale.ROOT));
+			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + Translatable.of("msg_err_cannot_claim_land_without_homeblock").translate(Locale.ROOT));
 			return;
 		}
 		
@@ -218,7 +218,7 @@ public class TownyListener implements Listener {
 					errorMessage = Translatable.of("msg_err_outpost_claim_rules_home");
 				}
 				event.setCancelled(true);
-				event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + " " + errorMessage.translate(Locale.ROOT));
+				event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + errorMessage.translate(Locale.ROOT));
 				return;
 			}
 			
@@ -226,7 +226,7 @@ public class TownyListener implements Listener {
 			int numTownBlocksInProvince = TownyProvincesDataHolder.getInstance().getNumTownBlocksInProvince(event.getTown(), provinceAtClaimLocation);
 			if (numTownBlocksInProvince >= TownyProvincesSettings.getMaxNumTownBlocksInEachForeignProvince()) {
 				event.setCancelled(true);
-				event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + " " + Translatable.of("msg_err_too_many_townblocks_in_province").translate(Locale.ROOT));
+				event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + Translatable.of("msg_err_too_many_townblocks_in_province", TownyProvincesSettings.getMaxNumTownBlocksInEachForeignProvince()).translate(Locale.ROOT));
 				return;
 			}
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -17,6 +17,7 @@ import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.TranslationLoader;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
@@ -24,6 +25,7 @@ import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 import io.github.townyadvanced.townyprovinces.metadata.TownMetaDataController;
 import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.objects.ProvinceType;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFinalCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
@@ -99,9 +101,10 @@ public class TownyListener implements Listener {
 			return;
 		}
 		//Can't place town in Sea province
-		if (province.isSea()) {
+		if (!province.getType().canNewTownsBeCreated()) {
+			String provinceTypeTranslation = Translation.of("word_" + province.getType().name().toLowerCase());
 			event.setCancelled(true);
-			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + Translatable.of("msg_err_cannot_create_town_in_sea_provinces").translate(Locale.ROOT));
+			event.setCancelMessage(TownyProvinces.getTranslatedPrefix() + Translatable.of("msg_err_cannot_create_town_in_province_type", provinceTypeTranslation).translate(Locale.ROOT));
 			return;
 		}
 		//Can't place new town is province-at-location already has one

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
@@ -28,7 +28,7 @@ public class Province {
 	
 	public Province(TPCoord homeBlock) {
 		this.homeBlock = homeBlock;
-		this.type = ProvinceType.CIVILISED;
+		this.type = ProvinceType.CIVILIZED;
 		this.newTownCost = 0;
 		this.upkeepTownCost = 0;
 		this.id = "province_x" + homeBlock.getX() + "_z_" + homeBlock.getZ();

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/Province.java
@@ -12,7 +12,7 @@ public class Province {
 	private final TPCoord homeBlock;
 	private double newTownCost;  //The base cost, not adjusted by biome
 	private double upkeepTownCost;  //The base cost, not adjusted by biome
-	private boolean isSea;
+	private ProvinceType type;  //Civilized, Sea, Wasteland
 	private final String id; //convenience variable. In memory only. Used for dynmap and file operations
 	private boolean landValidationRequested;
 	private double estimatedProportionOfGoodLand;
@@ -28,7 +28,7 @@ public class Province {
 	
 	public Province(TPCoord homeBlock) {
 		this.homeBlock = homeBlock;
-		this.isSea = false;
+		this.type = ProvinceType.CIVILISED;
 		this.newTownCost = 0;
 		this.upkeepTownCost = 0;
 		this.id = "province_x" + homeBlock.getX() + "_z_" + homeBlock.getZ();
@@ -77,12 +77,12 @@ public class Province {
 		return goodLandCost + waterCost + hotLandCost + coldLandCost;
 	}
 	
-	public boolean isSea() { 
-		return isSea; 
+	public ProvinceType getType() { 
+		return type; 
 	}
 	
-	public void setSea(boolean b) {
-		this.isSea = b;
+	public void setType(ProvinceType p) {
+		this.type = p;
 	}
 
 	public List<TPCoord> getListOfCoordsInProvince() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
@@ -1,0 +1,74 @@
+package io.github.townyadvanced.townyprovinces.objects;
+
+import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+
+public enum ProvinceType {
+	CIVILISED,
+	SEA,
+	WASTELAND;
+
+	public static ProvinceType parseProvinceType(String typeAsString) {
+		if(typeAsString.equalsIgnoreCase("civilized")) {
+			return CIVILISED;
+		} else if(typeAsString.equalsIgnoreCase("sea")) {
+			return SEA;
+		} else if(typeAsString.equalsIgnoreCase("wasteland")) {
+			return WASTELAND;
+		} else {
+			throw new RuntimeException("Unknown province type");		
+		}
+	}
+
+	public int getBorderColour() {
+		switch(this) {
+			case CIVILISED:
+				return TownyProvincesSettings.getCivilizedProvinceBorderColour();
+			case SEA:
+				return TownyProvincesSettings.getSeaProvinceBorderColour();
+			case WASTELAND:
+				return TownyProvincesSettings.getWastelandProvinceBorderColour();
+			default:
+				throw new RuntimeException("Unknown province type");
+		}
+	}
+
+	public int getBorderWeight() {
+		switch(this) {
+			case CIVILISED:
+				return TownyProvincesSettings.getCivilizedProvinceBorderWeight();
+			case SEA:
+				return TownyProvincesSettings.getSeaProvinceBorderWeight();
+			case WASTELAND:
+				return TownyProvincesSettings.getWastelandProvinceBorderWeight();
+			default:
+				throw new RuntimeException("Unknown province type");
+		}
+	}
+
+	public double getBorderOpacity() {
+		switch(this) {
+			case CIVILISED:
+				return TownyProvincesSettings.getCivilizedProvinceBorderOpacity();
+			case SEA:
+				return TownyProvincesSettings.getSeaProvinceBorderOpacity();
+			case WASTELAND:
+				return TownyProvincesSettings.getWastelandProvinceBorderOpacity();
+			default:
+				throw new RuntimeException("Unknown province type");
+		}
+	}
+	
+	public boolean canNewTownsBeCreated() {
+		switch(this) {
+			case CIVILISED:
+				return TownyProvincesSettings.getCivilizedProvinceNewTownsAllowed();
+			case SEA:
+				return TownyProvincesSettings.getSeaProvinceNewTownsAllowed();
+			case WASTELAND:
+				return TownyProvincesSettings.getWastelandProvinceNewTownsAllowed();
+			default:
+				throw new RuntimeException("Unknown province type");
+		}
+	}
+
+}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
@@ -61,14 +61,25 @@ public enum ProvinceType {
 	public boolean canNewTownsBeCreated() {
 		switch(this) {
 			case CIVILISED:
-				return TownyProvincesSettings.getCivilizedProvinceNewTownsAllowed();
+				return true;
 			case SEA:
-				return TownyProvincesSettings.getSeaProvinceNewTownsAllowed();
 			case WASTELAND:
-				return TownyProvincesSettings.getWastelandProvinceNewTownsAllowed();
+				return false;
 			default:
 				throw new RuntimeException("Unknown province type");
 		}
 	}
 
+	public boolean canForeignOutpostsBeCreated() {
+		switch(this) {
+			case CIVILISED:
+				return false;
+			case SEA:
+				return TownyProvincesSettings.getSeaProvinceOutpostsAllowed();
+			case WASTELAND:
+				return TownyProvincesSettings.getWastelandProvinceOutpostsAllowed();
+			default:
+				throw new RuntimeException("Unknown province type");
+		}
+	}
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceType.java
@@ -3,13 +3,13 @@ package io.github.townyadvanced.townyprovinces.objects;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 
 public enum ProvinceType {
-	CIVILISED,
+	CIVILIZED,
 	SEA,
 	WASTELAND;
 
 	public static ProvinceType parseProvinceType(String typeAsString) {
 		if(typeAsString.equalsIgnoreCase("civilized")) {
-			return CIVILISED;
+			return CIVILIZED;
 		} else if(typeAsString.equalsIgnoreCase("sea")) {
 			return SEA;
 		} else if(typeAsString.equalsIgnoreCase("wasteland")) {
@@ -21,7 +21,7 @@ public enum ProvinceType {
 
 	public int getBorderColour() {
 		switch(this) {
-			case CIVILISED:
+			case CIVILIZED:
 				return TownyProvincesSettings.getCivilizedProvinceBorderColour();
 			case SEA:
 				return TownyProvincesSettings.getSeaProvinceBorderColour();
@@ -34,7 +34,7 @@ public enum ProvinceType {
 
 	public int getBorderWeight() {
 		switch(this) {
-			case CIVILISED:
+			case CIVILIZED:
 				return TownyProvincesSettings.getCivilizedProvinceBorderWeight();
 			case SEA:
 				return TownyProvincesSettings.getSeaProvinceBorderWeight();
@@ -47,7 +47,7 @@ public enum ProvinceType {
 
 	public double getBorderOpacity() {
 		switch(this) {
-			case CIVILISED:
+			case CIVILIZED:
 				return TownyProvincesSettings.getCivilizedProvinceBorderOpacity();
 			case SEA:
 				return TownyProvincesSettings.getSeaProvinceBorderOpacity();
@@ -60,7 +60,7 @@ public enum ProvinceType {
 	
 	public boolean canNewTownsBeCreated() {
 		switch(this) {
-			case CIVILISED:
+			case CIVILIZED:
 				return true;
 			case SEA:
 			case WASTELAND:
@@ -72,7 +72,7 @@ public enum ProvinceType {
 
 	public boolean canForeignOutpostsBeCreated() {
 		switch(this) {
-			case CIVILISED:
+			case CIVILIZED:
 				return false;
 			case SEA:
 				return TownyProvincesSettings.getSeaProvinceOutpostsAllowed();

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -161,7 +161,7 @@ public enum ConfigNodes {
 		"# This value determines the weight of the border."),
 	WASTELAND_BORDER_APPEARANCE_OPACITY(
 		"province_types.wasteland.border_appearance.opacity",
-		"0.1",
+		"1",
 		"",
 		"# This value determines the opacity of the border."),
 	WASTELAND_BORDER_APPEARANCE_COLOUR(

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -60,53 +60,123 @@ public enum ConfigNodes {
 		"0.1",
 		"",
 		"# Snow and ice. Very hard to live in."),
-	PROVINCE_VISUALS(
-		"province_visuals",
+	PROVINCE_TYPES(
+		"province_types",
 		"",
 		"",
 		"",
 		"############################################################",
 		"# +------------------------------------------------------+ #",
-		"# |                   PROVINCE VISUALS                   | #",
+		"# |                   PROVINCE TYPES                   | #",
 		"# +------------------------------------------------------+ #",
 		"############################################################",
 		""),
-	LAND_PROVINCE_BORDER(
-		"province_visuals.land_province_border",
+	CIVILIZED(
+		"province_types.civilized",
+		"",
+		"",
+		"",
+		"# +------------------------------------------------------+ #",
+		"# |                      CIVILIZED                       | #",
+		"# +------------------------------------------------------+ #",
+		""),
+	CIVILIZED_NEW_TOWNS_ALLOWED(
+		"province_types.civilized.new_towns_allowed",
+		"true",
+		""),
+	CIVILIZED_OUTPOSTS_ALLOWED(
+		"province_types.civilized.foreign_outposts_allowed",
+		"false",
+		""),
+	CIVILIZED_BORDER_APPEARANCE(
+		"province_types.civilized.border_appearance",
 		"",
 		""),
-	LAND_PROVINCE_BORDER_WEIGHT(
-		"province_visuals.land_province_border.weight",
+	CIVILIZED_BORDER_APPEARANCE_WEIGHT(
+		"province_types.civilized.border_appearance.weight",
 		"1",
 		"",
 		"# This value determines the weight of the border."),
-	LAND_PROVINCE_BORDER_OPACITY(
-		"province_visuals.land_province_border.opacity",
+	CIVILIZED_BORDER_APPEARANCE_OPACITY(
+		"province_types.civilized.border_appearance.opacity",
 		"1",
 		"",
 		"# This value determines the opacity of the border."),
-	LAND_PROVINCE_BORDER_COLOUR(
-		"province_visuals.land_province_border.color",
+	CIVILIZED_BORDER_APPEARANCE_COLOUR(
+		"province_types.civilized.border_appearance.color",
 		"0",
 		"",
 		"# This value, in hex format, determines the color of the border."),
-	SEA_PROVINCE_BORDER(
-		"province_visuals.sea_province_border",
+	SEA(
+		"province_types.sea",
+		"",
+		"",
+		"",
+		"# +------------------------------------------------------+ #",
+		"# |                          SEA                         | #",
+		"# +------------------------------------------------------+ #",
+		""),
+	SEA_NEW_TOWNS_ALLOWED(
+		"province_types.sea.new_towns_allowed",
+		"false",
+		""),
+	SEA_OUTPOSTS_ALLOWED(
+		"province_types.sea.foreign_outposts_allowed",
+		"true",
+		""),
+	SEA_BORDER_APPEARANCE(
+		"province_types.sea.border_appearance",
 		"",
 		""),
-	SEA_PROVINCE_BORDER_WEIGHT(
-		"province_visuals.sea_province_border.weight",
+	SEA_BORDER_APPEARANCE_WEIGHT(
+		"province_types.sea.border_appearance.weight",
 		"1",
 		"",
 		"# This value determines the weight of the border."),
-	SEA_PROVINCE_BORDER_OPACITY(
-		"province_visuals.sea_province_border.opacity",
+	SEA_BORDER_APPEARANCE_OPACITY(
+		"province_types.sea.border_appearance.opacity",
 		"0.1",
 		"",
-		"# This value determines the opcacity of the border."),
-	SEA_PROVINCE_BORDER_COLOUR(
-		"province_visuals.sea_province_border.color",
+		"# This value determines the opacity of the border."),
+	SEA_BORDER_APPEARANCE_COLOUR(
+		"province_types.sea.border_appearance.color",
 		"33FFFF",
+		"",
+		"# This value, in hex format, determines the color of the border."),
+	WASTELAND(
+		"province_types.wasteland",
+		"",
+		"",
+		"",
+		"# +------------------------------------------------------+ #",
+		"# |                      WASTELAND                       | #",
+		"# +------------------------------------------------------+ #",
+		""),
+	WASTELAND_NEW_TOWNS_ALLOWED(
+		"province_types.wasteland.new_towns_allowed",
+		"false",
+		""),
+	WASTELAND_OUTPOSTS_ALLOWED(
+		"province_types.wasteland.foreign_outposts_allowed",
+		"true",
+		""),
+	WASTELAND_BORDER_APPEARANCE(
+		"province_types.wasteland.border_appearance",
+		"",
+		""),
+	WASTELAND_BORDER_APPEARANCE_WEIGHT(
+		"province_types.wasteland.border_appearance.weight",
+		"1",
+		"",
+		"# This value determines the weight of the border."),
+	WASTELAND_BORDER_APPEARANCE_OPACITY(
+		"province_types.wasteland.border_appearance.opacity",
+		"0.1",
+		"",
+		"# This value determines the opacity of the border."),
+	WASTELAND_BORDER_APPEARANCE_COLOUR(
+		"province_types.wasteland.border_appearance.color",
+		"333",
 		"",
 		"# This value, in hex format, determines the color of the border."),
 	TRAVEL(

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -29,8 +29,8 @@ public enum ConfigNodes {
 		"# Governs the pause between biome lookups.",
 		"# A high value will make the landvalidation job run slow",
 		"# A low value will make the landvalidation job take up lots of CPU"),
-	MAX_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE(
-		"max_townblocks_in_each_foreign_province",
+	MAX_NUM_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE(
+		"max_num_townblocks_in_each_foreign_province",
 		"8",
 		"",
 		"# Determines how many townblocks a town can have in each foreign province.",

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -176,7 +176,7 @@ public enum ConfigNodes {
 		"# This value determines the opacity of the border."),
 	WASTELAND_BORDER_APPEARANCE_COLOUR(
 		"province_types.wasteland.border_appearance.color",
-		"333",
+		"e60909",
 		"",
 		"# This value, in hex format, determines the color of the border."),
 	TRAVEL(

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -29,6 +29,12 @@ public enum ConfigNodes {
 		"# Governs the pause between biome lookups.",
 		"# A high value will make the landvalidation job run slow",
 		"# A low value will make the landvalidation job take up lots of CPU"),
+	MAX_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE(
+		"max_townblocks_in_each_foreign_province",
+		"8",
+		"",
+		"# Determines how many townblocks a town can have in each foreign province.",
+		"# These townblocks can only be unlocked by building an outpost in a sea or wasteland province."),
 	BIOME_COST_ADJUSTMENTS(
 		"biome_cost_adjustments",
 		"",
@@ -80,14 +86,6 @@ public enum ConfigNodes {
 		"# |                      CIVILIZED                       | #",
 		"# +------------------------------------------------------+ #",
 		""),
-	CIVILIZED_NEW_TOWNS_ALLOWED(
-		"province_types.civilized.new_towns_allowed",
-		"true",
-		""),
-	CIVILIZED_OUTPOSTS_ALLOWED(
-		"province_types.civilized.foreign_outposts_allowed",
-		"false",
-		""),
 	CIVILIZED_BORDER_APPEARANCE(
 		"province_types.civilized.border_appearance",
 		"",
@@ -115,10 +113,6 @@ public enum ConfigNodes {
 		"# +------------------------------------------------------+ #",
 		"# |                          SEA                         | #",
 		"# +------------------------------------------------------+ #",
-		""),
-	SEA_NEW_TOWNS_ALLOWED(
-		"province_types.sea.new_towns_allowed",
-		"false",
 		""),
 	SEA_OUTPOSTS_ALLOWED(
 		"province_types.sea.foreign_outposts_allowed",
@@ -151,10 +145,6 @@ public enum ConfigNodes {
 		"# +------------------------------------------------------+ #",
 		"# |                      WASTELAND                       | #",
 		"# +------------------------------------------------------+ #",
-		""),
-	WASTELAND_NEW_TOWNS_ALLOWED(
-		"province_types.wasteland.new_towns_allowed",
-		"false",
 		""),
 	WASTELAND_OUTPOSTS_ALLOWED(
 		"province_types.wasteland.foreign_outposts_allowed",

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -157,34 +157,46 @@ public class TownyProvincesSettings {
 		return Double.parseDouble(numberString);
 	}
 	
-	public static int getLandProvinceBorderWeight() {
-		return Settings.getInt(ConfigNodes.LAND_PROVINCE_BORDER_WEIGHT);
+	public static int getCivilizedProvinceBorderWeight() {
+		return Settings.getInt(ConfigNodes.CIVILIZED_BORDER_APPEARANCE_WEIGHT);
 	}
 
-	public static double getLandProvinceBorderOpacity() {
-		return Settings.getDouble(ConfigNodes.LAND_PROVINCE_BORDER_OPACITY);
+	public static double getCivilizedProvinceBorderOpacity() {
+		return Settings.getDouble(ConfigNodes.CIVILIZED_BORDER_APPEARANCE_OPACITY);
+	}
+
+	public static int getCivilizedProvinceBorderColour() {
+		return Integer.parseInt(Settings.getString(ConfigNodes.CIVILIZED_BORDER_APPEARANCE_COLOUR),16);
+	}
+
+	public static int getWastelandProvinceBorderWeight() {
+		return Settings.getInt(ConfigNodes.WASTELAND_BORDER_APPEARANCE_WEIGHT);
+	}
+
+	public static double getWastelandProvinceBorderOpacity() {
+		return Settings.getDouble(ConfigNodes.WASTELAND_BORDER_APPEARANCE_OPACITY);
+	}
+
+	public static int getWastelandProvinceBorderColour() {
+		return Integer.parseInt(Settings.getString(ConfigNodes.WASTELAND_BORDER_APPEARANCE_COLOUR),16);
+	}
+	
+	public static int getSeaProvinceBorderWeight() {
+		return Settings.getInt(ConfigNodes.SEA_BORDER_APPEARANCE_WEIGHT);
+	}
+
+	public static double getSeaProvinceBorderOpacity() {
+		return Settings.getDouble(ConfigNodes.SEA_BORDER_APPEARANCE_OPACITY);
+	}
+
+	public static int getSeaProvinceBorderColour() {
+		return Integer.parseInt(Settings.getString(ConfigNodes.SEA_BORDER_APPEARANCE_COLOUR),16);
 	}
 
 	public static int getPauseMillisecondsBetweenBiomeLookups() {
 		return Settings.getInt(ConfigNodes.PAUSE_MILLISECONDS_BETWEEN_BIOME_LOOKUPS);
 	}
 
-	public static int getLandProvinceBorderColour() {
-		return Integer.parseInt(Settings.getString(ConfigNodes.LAND_PROVINCE_BORDER_COLOUR),16);
-	}
-
-	public static int getSeaProvinceBorderWeight() {
-		return Settings.getInt(ConfigNodes.SEA_PROVINCE_BORDER_WEIGHT);
-	}
-
-	public static double getSeaProvinceBorderOpacity() {
-		return Settings.getDouble(ConfigNodes.SEA_PROVINCE_BORDER_OPACITY);
-	}
-
-	public static int getSeaProvinceBorderColour() {
-		return Integer.parseInt(Settings.getString(ConfigNodes.SEA_PROVINCE_BORDER_COLOUR),16);
-	}
-	
 	public static List<String> getOrderedRegionNames() {
 		return orderedRegionNames;
 	}
@@ -254,5 +266,30 @@ public class TownyProvincesSettings {
 
 	public static double getBiomeCostAdjustmentsHotLand() { return Settings.getDouble(ConfigNodes.BIOME_COST_ADJUSTMENTS_HOT_LAND); }
 	public static double getBiomeCostAdjustmentsColdLand() { return Settings.getDouble(ConfigNodes.BIOME_COST_ADJUSTMENTS_COLD_LAND); }
+
+	public static boolean getCivilizedProvinceNewTownsAllowed() {
+		return Settings.getBoolean(ConfigNodes.CIVILIZED_NEW_TOWNS_ALLOWED);
+	}
+	
+	public static boolean getSeaProvinceNewTownsAllowed() {
+		return Settings.getBoolean(ConfigNodes.WASTELAND_NEW_TOWNS_ALLOWED);
+	}
+	
+	public static boolean getWastelandProvinceNewTownsAllowed() {
+		return Settings.getBoolean(ConfigNodes.SEA_NEW_TOWNS_ALLOWED);
+	}
+
+
+	public static boolean getCivilizedProvinceOutpostsAllowed() {
+		return Settings.getBoolean(ConfigNodes.CIVILIZED_NEW_TOWNS_ALLOWED);
+	}
+
+	public static boolean getSeaProvinceOutpostsAllowed() {
+		return Settings.getBoolean(ConfigNodes.SEA_OUTPOSTS_ALLOWED);
+	}
+
+	public static boolean getWastelandProvinceOutpostsAllowed() {
+		return Settings.getBoolean(ConfigNodes.WASTELAND_OUTPOSTS_ALLOWED);
+	}
 
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -267,23 +267,6 @@ public class TownyProvincesSettings {
 	public static double getBiomeCostAdjustmentsHotLand() { return Settings.getDouble(ConfigNodes.BIOME_COST_ADJUSTMENTS_HOT_LAND); }
 	public static double getBiomeCostAdjustmentsColdLand() { return Settings.getDouble(ConfigNodes.BIOME_COST_ADJUSTMENTS_COLD_LAND); }
 
-	public static boolean getCivilizedProvinceNewTownsAllowed() {
-		return Settings.getBoolean(ConfigNodes.CIVILIZED_NEW_TOWNS_ALLOWED);
-	}
-	
-	public static boolean getSeaProvinceNewTownsAllowed() {
-		return Settings.getBoolean(ConfigNodes.WASTELAND_NEW_TOWNS_ALLOWED);
-	}
-	
-	public static boolean getWastelandProvinceNewTownsAllowed() {
-		return Settings.getBoolean(ConfigNodes.SEA_NEW_TOWNS_ALLOWED);
-	}
-
-
-	public static boolean getCivilizedProvinceOutpostsAllowed() {
-		return Settings.getBoolean(ConfigNodes.CIVILIZED_NEW_TOWNS_ALLOWED);
-	}
-
 	public static boolean getSeaProvinceOutpostsAllowed() {
 		return Settings.getBoolean(ConfigNodes.SEA_OUTPOSTS_ALLOWED);
 	}
@@ -292,4 +275,8 @@ public class TownyProvincesSettings {
 		return Settings.getBoolean(ConfigNodes.WASTELAND_OUTPOSTS_ALLOWED);
 	}
 
+	public static int getMaxTownBlocksInEachForeignProvince() {
+		return Settings.getInt(ConfigNodes.MAX_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE);
+	}
+	
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -275,8 +275,8 @@ public class TownyProvincesSettings {
 		return Settings.getBoolean(ConfigNodes.WASTELAND_OUTPOSTS_ALLOWED);
 	}
 
-	public static int getMaxTownBlocksInEachForeignProvince() {
-		return Settings.getInt(ConfigNodes.MAX_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE);
+	public static int getMaxNumTownBlocksInEachForeignProvince() {
+		return Settings.getInt(ConfigNodes.MAX_NUM_TOWNBLOCKS_IN_EACH_FOREIGN_PROVINCE);
 	}
 	
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -98,6 +98,17 @@ msg_err_cannot_claim_land_on_province_border: "&cTowns cannot claim land on prov
 msg_err_cannot_claim_land_without_homeblock: "&cTowns without homeblocks cannot claim land."
 msg_err_cannot_claim_land_outside_own_province: "&cTowns cannot claim land outside their own provinces."
 
+# Outposts
+
+msg_err_outpost_claim_rules_home: "&cYou cannot claim an outpost here. Outposts can only be claimed in the Town's home province."
+msg_err_outpost_claim_rules_home_sea: "&cYou cannot claim an outpost here. Outposts can only be claimed in Sea provinces, and in the Town's Home-province."
+msg_err_outpost_claim_rules_home_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Wasteland provinces, and in the Town's Home-province."
+msg_err_outpost_claim_rules_home_sea_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Sea provinces, Wasteland provinces, and in the Town's Home-provinces"
+msg_err_too_many_townblocks_in_province: "&cYou have already claimed the maximum number townblocks in this province. In any province other than its home province, a town can have a maximum of %d townblocks."
+
+
+
+
 #Dynmap
 
 dynmap_province_homeblock_label: "Town Costs: New %s, Upkeep %s"

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -31,15 +31,15 @@ townyprovinces_plugin_prefix: '&6[TownyProvinces] '
 
 msg_err_unknown_world: "&cERROR: The world_name field in TownyProvinces/config.yml in incorrect. It must be the name of a world on your server."
 
-# Set province to land or sea
+# Set province type
 
+word_civilized: "Civilized"
+word_sea: "Sea"
+word_wasteland: "Wasteland"
+msg_province_already_given_type: "&cProvince type is already %s."
+msg_province_type_successfully_set: "&bProvince type was set to %s. The map will be updated shortly."
+msg_province_types_in_area_successfully_set: "&bAll provinces in the given area were set to type %s."
 msg_err_invalid_province_location: "&cThe given co-ordinate was either mis-formatted, on a border, or outside the map."
-msg_province_successfully_set_to_sea: "&bProvince type was set to Sea. The map will be updated shortly."
-msg_province_already_sea: "&cProvince type is already Sea."
-msg_province_successfully_set_to_land: "&bProvince type was set to Land. The map will be updated shortly."
-msg_province_already_land: "&cProvince type is already Land."
-msg_provinces_in_area_set_to_sea: "&bAll provinces in the given area were set to type Sea."
-msg_provinces_in_area_set_to_land: "&bAll provinces in the given area were set to type Land."
 
 # Regenerate region
 
@@ -83,7 +83,7 @@ land_validation_job_status_restart_requested: "&aRestart Requested"
 # Creating new towns
 
 msg_err_cannot_create_town_on_province_border: "&cTowns cannot be created on province borders."
-msg_err_cannot_create_town_in_sea_provinces: "&cTowns cannot be created in Sea provinces."
+msg_err_cannot_create_town_in_province_type: "&cTowns cannot be created in %s provinces."
 msg_err_cannot_create_town_in_full_province: "&cOnly 1 town is allowed in each province. This province already contains a town."
 msg_err_cannot_afford_new_town: "&cYou can't afford to settle a new town in this province, which costs %s."
 msg_you_paid_region_settlement_cost: "&aYou paid the region settlement cost of %s."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -100,10 +100,10 @@ msg_err_cannot_claim_land_outside_own_province: "&cTowns cannot claim land outsi
 
 # Outposts
 
-msg_err_outpost_claim_rules_home: "&cYou cannot claim an outpost here. Outposts can only be claimed in the Town's home province."
-msg_err_outpost_claim_rules_home_sea: "&cYou cannot claim an outpost here. Outposts can only be claimed in Sea provinces, and in the Town's Home-province."
-msg_err_outpost_claim_rules_home_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Wasteland provinces, and in the Town's Home-province."
-msg_err_outpost_claim_rules_home_sea_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Sea provinces, Wasteland provinces, and in the Town's Home-provinces"
+msg_err_outpost_claim_rules_home: "&cYou cannot claim an outpost here. Outposts can only be claimed in the Town's Home-Province."
+msg_err_outpost_claim_rules_home_sea: "&cOutposts can only be claimed in Sea-Provinces, and in the Town's Home-Province."
+msg_err_outpost_claim_rules_home_wasteland: "&cOutposts can only be claimed in Wasteland-Provinces, and in the Town's Home-Province."
+msg_err_outpost_claim_rules_home_sea_wasteland: "&cOutposts can only be claimed in Sea-Provinces, Wasteland-Provinces, and in the Town's Home-Province."
 msg_err_too_many_townblocks_in_province: "&cYou have already claimed the maximum number townblocks in this province. In any province other than its home province, a town can have a maximum of %d townblocks."
 msg_err_cannot_move_homeblock_to_different_province: "&cYou cannot move your Home-Block to a different province."
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -105,8 +105,7 @@ msg_err_outpost_claim_rules_home_sea: "&cYou cannot claim an outpost here. Outpo
 msg_err_outpost_claim_rules_home_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Wasteland provinces, and in the Town's Home-province."
 msg_err_outpost_claim_rules_home_sea_wasteland: "&cYou cannot claim an outpost here. Outposts can only be claimed in Sea provinces, Wasteland provinces, and in the Town's Home-provinces"
 msg_err_too_many_townblocks_in_province: "&cYou have already claimed the maximum number townblocks in this province. In any province other than its home province, a town can have a maximum of %d townblocks."
-
-
+msg_err_cannot_move_homeblock_to_different_province: "&cYou cannot move your Home-Block to a different province."
 
 
 #Dynmap


### PR DESCRIPTION
- Refactored land/sea plots to civilized/sea/wasteland
- Outposts can be placed in home province as before, and now can also be placed (by default) on wasteland or sea provinces.
- When an outpost if placed in a foreign province, a town cannot expand indefinitely from there. The town is limited to x townblocks (8 by default)

Closes #75 
