### PR TITLE
Add Protected Locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.townyadvanced</groupId>
   <artifactId>TownyProvinces</artifactId>
-  <version>1.15.0</version>
+  <version>1.16.0</version>
   <name>townyprovinces</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -133,8 +133,8 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 					//Province is settle-able. If the marker is not there, we need to add it
 					if(homeBlockMarker != null)
 						continue;
-					int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
-					int realHomeBlockZ = homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength();
+					int realHomeBlockX = (homeBlock.getX() * TownyProvincesSettings.getChunkSideLength()) + 8;
+					int realHomeBlockZ = (homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength()) + 8;
 
 					String markerLabel;
 					if(TownyEconomyHandler.isActive()) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -123,8 +123,8 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 					//This is land If the marker is not there, we need to add it
 					if(homeBlockMarker != null)
 						continue;
-					int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
-					int realHomeBlockZ = homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength();
+					int realHomeBlockX = (homeBlock.getX() * TownyProvincesSettings.getChunkSideLength()) + 8;
+					int realHomeBlockZ = (homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength()) + 8;
 
 					String markerLabel;
 					if(TownyEconomyHandler.isActive()) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -45,9 +45,7 @@ public class PaintRegionAction {
 	private final Location bottomRightRegionCorner;
 	private final int averageProvinceSize;
 	private final int maxBrushMoves;
-	private final double newTownCostPerChunk;
-	private final double upkeepTownCostPerChunk;
-	private final Set<Location> protectedLocations;
+	private final Map<String, Location> protectedLocations;
 	
 	public PaintRegionAction(String regionName, Map<TPCoord,TPCoord> unclaimedCoordsMap) {
 		TownyProvinces.info("-------------------------------");
@@ -73,8 +71,6 @@ public class PaintRegionAction {
 		this.bottomRightRegionCorner = TownyProvincesSettings.getBottomRightCornerLocation(regionName);
 		this.averageProvinceSize = TownyProvincesSettings.getAverageProvinceSize(regionName);
 		this.maxBrushMoves = TownyProvincesSettings.getMaxBrushMoves(regionName);
-		this.newTownCostPerChunk = TownyProvincesSettings.getNewTownCostPerChunk(regionName);
-		this.upkeepTownCostPerChunk = TownyProvincesSettings.getUpkeepTownCostPerChunk(regionName);
 		this.protectedLocations = TownyProvincesSettings.getProtectedLocations(regionName);
 	}
 	
@@ -87,10 +83,9 @@ public class PaintRegionAction {
 		}
 
 		/*
-		 * Create province objects - empty except for the homeblocks
-		 * This is the start point for the paint brushes
+		 * Create provinces including the initial claimed area
 		 */
-		if(!generateProvinceObjects()) {
+		if(!generateProvinces()) {
 			return false;
 		}
 
@@ -153,29 +148,33 @@ public class PaintRegionAction {
 	 *
 	 * @return false if we failed to create sufficient province objects
 	 */
-	private boolean generateProvinceObjects() {
+	private boolean generateProvinces() {
 		TownyProvinces.info("Now generating province objects");
 		Province province;
 		int maxNumProvinces = calculateMaxNumberOfProvinces();
 		int maxNumRandomProvinces = maxNumProvinces - protectedLocations.size();
 		int provincesCreated = 0;
 		//Generate provinces at protected locations
-		for(Location location: protectedLocations) {
-			TownyProvinces.info("Now generating protected provice at " + location);
-			province = generateProtectedProvince(location);
-			TownyProvincesDataHolder.getInstance().addProvince(province);
-			TownyProvinces.info("ID =  " + province.getId());
-			provincesCreated++;
+		for(Map.Entry<String,Location> mapEntry: protectedLocations.entrySet()) {
+			TownyProvinces.info("Now generating province at protected location: " + mapEntry.getKey());
+			province = generateProtectedProvince(mapEntry.getValue());
+			if(province == null) {
+				TownyProvinces.severe("Could not generate province at protected location: " + mapEntry.getKey());
+				return false;
+			} else {
+				TownyProvincesDataHolder.getInstance().addProvince(province);
+				provincesCreated++;
+			}
 		}
 		//Generate provinces at random locations
 		for (int randomProvinceIndex = 0; randomProvinceIndex < maxNumRandomProvinces; randomProvinceIndex++) {
 			province = generateRandomlyPlacedProvince();
-			if(province != null) {
+			if(province == null) {
+				break; //We created as many as we could in this region
+			} else {
 				//Province object created successfully. Add to data holder
 				TownyProvincesDataHolder.getInstance().addProvince(province);
 				provincesCreated++;
-			} else {
-				break; //We created as many as we could in this region
 			}
 		}
 		TownyProvinces.info("" + provincesCreated + " province objects created.");
@@ -204,7 +203,14 @@ public class PaintRegionAction {
 	private Province generateProtectedProvince(Location location) {
 		Coord coord = Coord.parseCoord(location);
 		TPCoord homeBlockCoord = new TPFinalCoord(coord.getX(), coord.getZ());
-		return new Province(homeBlockCoord);
+		Province province = new Province(homeBlockCoord);
+		if(validateBrushPosition(homeBlockCoord.getX(), homeBlockCoord.getZ(), province)) {
+			ProvinceClaimBrush brush = new ProvinceClaimBrush(province);
+			claimChunksCoveredByBrush(brush);
+			return province;
+		} else {
+			return null;
+		}
 	}
 
 	/**
@@ -229,44 +235,23 @@ public class PaintRegionAction {
 			TPCoord homeBlockCoord = new TPFinalCoord(xCoord, zCoord);
 			//Create province object
 			Province province = new Province(homeBlockCoord);
-			//Validate province homeblock position
-			if(validatePositionOfProvinceHomeBlock(province)) {
+			//Validate province position
+			if(validateBrushPosition(homeBlockCoord.getX(), homeBlockCoord.getZ(), province)) {
+				ProvinceClaimBrush brush = new ProvinceClaimBrush(province);
+				claimChunksCoveredByBrush(brush);
 				return province;
 			}
 		}
 		return null;
 	}
 	
-	private boolean validatePositionOfProvinceHomeBlock(Province provinceToValidate) {
-		//Make sure it is far enough from other homeblocks
-		TPCoord homeBlockToValidate = provinceToValidate.getHomeBlock();
-		for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
-			/* 
-			* The minimum allowed distance is:
-			* (province square radius - (brush square radius * 2)) / 2 
-			 */
-			double minAllowedDistance = (int)(((double)provinceSquareRadius - ((double)brushSquareRadiusInChunks * TownyProvincesSettings.getChunkSideLength() * 2)) / 2);
-			int allowedDistanceInChunks = (int)(minAllowedDistance / TownyProvincesSettings.getChunkSideLength());
-			allowedDistanceInChunks = Math.max(allowedDistanceInChunks,1);
-			if(TownyProvincesMathUtil.minecraftDistanceBetweenCoords(homeBlockToValidate, province.getHomeBlock()) < allowedDistanceInChunks) {
-				return false;
-			}
-		}
-		//Make sure that it doesn't overlap existing claims, or go off the map border
-		if(validateBrushPosition(homeBlockToValidate.getX(), homeBlockToValidate.getZ(), provinceToValidate)) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
 	private boolean executeChunkClaimCompetition() {
 		TownyProvinces.info("Chunk Claim Competition Started");
 
 		//Create claim-brush objects
 		List<ProvinceClaimBrush> provinceClaimBrushes = new ArrayList<>();
 		for(Province province: TownyProvincesDataHolder.getInstance().getProvincesSet()) {
-			provinceClaimBrushes.add(new ProvinceClaimBrush(province, brushSquareRadiusInChunks));
+			provinceClaimBrushes.add(new ProvinceClaimBrush(province));
 		}
 		
 		/*
@@ -361,10 +346,10 @@ public class PaintRegionAction {
 		if(!validateBrushPosition(brush.getCurrentPosition().getX(), brush.getCurrentPosition().getZ(), brush.getProvince()))
 			return;
 			
-		int startX = brush.getCurrentPosition().getX() - brush.getSquareRadius();
-		int endX = brush.getCurrentPosition().getX() + brush.getSquareRadius();
-		int startZ = brush.getCurrentPosition().getZ() - brush.getSquareRadius();
-		int endZ = brush.getCurrentPosition().getZ() + brush.getSquareRadius();
+		int startX = brush.getCurrentPosition().getX() - brushSquareRadiusInChunks;
+		int endX = brush.getCurrentPosition().getX() + brushSquareRadiusInChunks;
+		int startZ = brush.getCurrentPosition().getZ() - brushSquareRadiusInChunks;
+		int endZ = brush.getCurrentPosition().getZ() + brushSquareRadiusInChunks;
 		for(int x = startX; x <= endX; x++) {
 			for(int z = startZ; z <= endZ; z++) {
 				//Claim chunk if not already claimed by the province
@@ -497,6 +482,7 @@ public class PaintRegionAction {
 		}
 		for(Province province: provincesToDelete) {
 			TownyProvincesDataHolder.getInstance().deleteProvince(province, unclaimedCoordsMap);
+			TownyProvinces.info("Province Deleted: " + province.getId());
 		}
 		TownyProvinces.info("Empty Provinces Deleted.");
 		return true;

--- a/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceClaimBrush.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/objects/ProvinceClaimBrush.java
@@ -2,14 +2,12 @@ package io.github.townyadvanced.townyprovinces.objects;
 
 public class ProvinceClaimBrush {
 	
-	private final int squareRadius;
 	private final TPFreeCoord currentPosition;
 	private final Province province;
 	private boolean active;
 	private int numChunksClaimed;
 	
-	public ProvinceClaimBrush(Province province, int squareRadius) {
-		this.squareRadius = squareRadius;
+	public ProvinceClaimBrush(Province province) {
 		this.province = province;
 		this.currentPosition = new TPFreeCoord(province.getHomeBlock().getX(), province.getHomeBlock().getZ());
 		this.active = true;
@@ -18,10 +16,6 @@ public class ProvinceClaimBrush {
 	
 	public void moveBrushTo(int xCoord, int zCoord) {
 		this.currentPosition.setValues(xCoord, zCoord);
-	}
-
-	public int getSquareRadius() {
-		return squareRadius;
 	}
 	
 	public TPFreeCoord getCurrentPosition() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -182,7 +182,7 @@ public enum ConfigNodes {
 		""),
 	MAP_REFRESH_PERIOD_MILLISECONDS(
 		"map_integration.refresh_period_seconds",
-		"60",
+		"15",
 		"",
 		"# The period between map refreshes.",
 		"# A high value is softer on your CPU.",

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -299,18 +299,19 @@ public class TownyProvincesSettings {
 		return Settings.getDouble(ConfigNodes.MAP_NATION_COLOURS_OPACITY);
 	}
 
-	public static Set<Location> getProtectedLocations(String regionName) {
-		Set<Location> result = new HashSet<>();
+	public static Map<String,Location> getProtectedLocations(String regionName) {
+		Map<String, Location> result = new HashMap<>();
 		Map<String, String> regionDefinitions = TownyProvincesSettings.getRegionDefinitions(regionName);
 		String locationsString = regionDefinitions.get("protected_locations");
 		if(locationsString != null) {
 			World world = getWorld();
 			String[] locationsArray = locationsString.split("\\|");
 			String[] singleLocationArray;
+			Location location;
 			for (String singleLocationString : locationsArray) {
 				singleLocationArray = singleLocationString.split(",");
-				TownyProvinces.info("Now Protecting Location: " + singleLocationArray[0]);
-				result.add(new Location(world, Integer.parseInt(singleLocationArray[1].trim()), 64, Integer.parseInt(singleLocationArray[2].trim())));
+				location =  new Location(world, Integer.parseInt(singleLocationArray[1].trim()), 64, Integer.parseInt(singleLocationArray[2].trim()));
+				result.put(singleLocationArray[0], location);
 			}
 		}
 		return result;

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -18,8 +18,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TownyProvincesSettings {
 
@@ -297,4 +299,20 @@ public class TownyProvincesSettings {
 		return Settings.getDouble(ConfigNodes.MAP_NATION_COLOURS_OPACITY);
 	}
 
+	public static Set<Location> getProtectedLocations(String regionName) {
+		Set<Location> result = new HashSet<>();
+		Map<String, String> regionDefinitions = TownyProvincesSettings.getRegionDefinitions(regionName);
+		String locationsString = regionDefinitions.get("protected_locations");
+		if(locationsString != null) {
+			World world = getWorld();
+			String[] locationsArray = locationsString.split("\\|");
+			String[] singleLocationArray;
+			for (String singleLocationString : locationsArray) {
+				singleLocationArray = singleLocationString.split(",");
+				TownyProvinces.info("Now Protecting Location: " + singleLocationArray[0]);
+				result.add(new Location(world, Integer.parseInt(singleLocationArray[1].trim()), 64, Integer.parseInt(singleLocationArray[2].trim())));
+			}
+		}
+		return result;
+	}
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/util/FileUtil.java
@@ -112,6 +112,7 @@ public class FileUtil {
 				fileEntries.add("max_brush_moves: 100");
 				fileEntries.add("new_town_cost_per_chunk: 7.2");
 				fileEntries.add("upkeep_town_cost_per_chunk: 0.72");
+				fileEntries.add("protected_locations: london,-2,-1172|paris,37,-1090|rome,282,-952");
 				folderPath = TownyProvinces.getPlugin().getDataFolder().toPath().resolve(FileUtil.REGION_DEFINITIONS_FOLDER_PATH).toString();
 				filePath = folderPath + "/" + fileName;
 				saveListIntoFile(fileEntries, filePath);


### PR DESCRIPTION
- By means of region def files, a server owner can specify "protected locations", which they don't want borders to run through
- Then when the generation runs, these will be protected
- Servers owners are recommended to ask players before generation which location they want to protection, because ideally you don't want to have to run this later after opening the server to players
- After opening to players, in a pinch you can still protect a location, by creating a localized region def file containing a protected location, and then generating that.
Closes #63
Closes #67