### PR TITLE
Fix Pl3xMap v3 stroke and fill colours

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -167,7 +167,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 	
 	@Override
 	protected void drawProvinceBorder(Province province) {
-		int borderColour = province.getType().getBorderColour() +
+		int borderColour = province.getType().getBorderColour() |
 			(int)(255*province.getType().getBorderOpacity()) << 24;
 		int borderWeight = province.getType().getBorderWeight();
 		String markerId = province.getId();
@@ -210,7 +210,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 	}
 
 	private void drawBorderLine(List<TPCoord> drawableLineOfBorderCoords, Province province, String markerId) {
-		int borderColour = province.getType().getBorderColour() +
+		int borderColour = province.getType().getBorderColour() |
 			(int)(255*province.getType().getBorderOpacity()) << 24;
 		int borderWeight = province.getType().getBorderWeight();
 
@@ -278,7 +278,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 		
 		Options markerOptions = Options.builder()
 			.stroke(stroke)
-			.fill(new Fill(false))
+			.fill(new Fill(0))
 			.build();
 		
 		polygonMarker.setOptions(markerOptions);
@@ -324,7 +324,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 				continue;
 			}
 			//Set border colour if needed
-			requiredBorderColour = province.getType().getBorderColour() +
+			requiredBorderColour = province.getType().getBorderColour() |
 				(int) (255 * province.getType().getBorderOpacity()) << 24;
 			requiredBorderWeight = province.getType().getBorderWeight();
 			if (stroke.getColor() != requiredBorderColour) {
@@ -332,7 +332,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 				stroke.setWeight(requiredBorderWeight);
 			}
 			//Set fill colour if needed
-			requiredFillColour = province.getFillColour() +
+			requiredFillColour = province.getFillColour() |
 				(int) (255 * province.getFillOpacity()) << 24;
 			if (fill.getColor() != requiredFillColour) {
 				fill.setColor(requiredFillColour);


### PR DESCRIPTION
Makes the following changes to correct mistakes in my previous PR:

- Corrects the ARGB logic in Pl3xMap v3 Action - This should be OR, not addition - This was pointed out by BillyGalbreath (Pl3xMap developer) when I asked about fill colour, thank you to him
- Defaults the fill to Zero (transparent black) instead of disabled - This was preventing the provinces being filled at all on Pl3xMap

I've tested this and it works as intended with parity to Dynmap