### PR TITLE
Bluemap fixes and cleanup

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -43,6 +43,8 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 		}
 		
 		BlueMapAPI.onEnable(e -> {
+			addProvinceBordersMarkerSet();
+			addProvinceHomeBlocksMarkerSet();
 			Path assetsFolder = e.getWebApp().getWebRoot().resolve("assets");
 			try (OutputStream out = Files.newOutputStream(assetsFolder.resolve("province.png"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
 				BufferedImage configIcon = TownyProvincesSettings.getTownCostsIcon();

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -184,13 +184,21 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 				}
 
 				if (fillColor.getRed() != 0 || fillColor.getGreen() != 0 || fillColor.getBlue() != 0) {
-					TownyProvinces.info("DEBUG: Fill color is " + shapeMarker.getFillColor().toString());
-					TownyProvinces.info("DEBUG: It should be " + fillColor);
+					TownyProvinces.info("DEBUG: Fill color is: Red" + shapeMarker.getFillColor().getRed() + " | Green: " + shapeMarker.getFillColor().getGreen() + " | Blue: " + shapeMarker.getFillColor().getBlue() + " | Alpha: " + shapeMarker.getFillColor().getAlpha());
+					TownyProvinces.info("DEBUG: It should be: Red " + fillColor.getRed() + " | Green: " + fillColor.getGreen() + " | Blue: " + fillColor.getBlue() + " | Alpha: " + fillColor.getAlpha());
 				}
 				if(!shapeMarker.getFillColor().equals(fillColor)){
 					TownyProvinces.info("DEBUG: Fill color does not match");
 					shapeMarker.setFillColor(fillColor);
 				}
+				TownyProvinces.info("DEBUG: Constructing a brand new shapemarker");
+				marker = ShapeMarker.builder()
+					.shape(shapeMarker.getShape(), 65)
+					.fillColor(fillColor)
+					.lineColor(borderColor)
+					.label(province.getId())
+					.depthTestEnabled(false)
+					.build();
 			}
 			TownyProvinces.info("DEBUG: Adding the marker back");
 			borderMarkerSet.put(province.getId(), marker);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -194,11 +194,10 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 
 	@Override
 	protected void drawProvinceBorder(Province province) {
-		int borderColour = province.getType().getBorderColour();
-		float borderOpacity = (float) province.getType().getBorderOpacity();
+		Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
 		String markerId = province.getId();
-		Marker shapeMarker = borderMarkerSet.get(markerId);
-			if (shapeMarker == null) {
+		Marker marker = borderMarkerSet.get(markerId);
+			if (marker == null) {
 				Set<TPCoord> borderCoords = findAllBorderCoords(province);
 				if (borderCoords.size() > 0) {
 					//Arrange border blocks into drawable line
@@ -212,12 +211,9 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 					}
 				}
 			}
-		if (shapeMarker instanceof ShapeMarker) {
-			if(!((ShapeMarker) shapeMarker).getLineColor().equals(borderColour)){
-				java.awt.Color provinceColor = new java.awt.Color(province.getType().getBorderColour());
-				Color color = new Color(provinceColor.getRed(), provinceColor.getGreen(), provinceColor.getBlue(), borderOpacity);
-				((ShapeMarker) shapeMarker).setLineColor(color);
-			}
+		if (marker instanceof ShapeMarker) {
+			ShapeMarker shapeMarker = (ShapeMarker) marker;
+			shapeMarker.setLineColor(borderColor);
 		}
 	}
 

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -173,7 +173,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 	protected void setProvinceMapStyles() {
 		Marker marker;
 		for(Province province : new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())){
-			marker = borderMarkerSet.remove(province.getId());
+			marker = borderMarkerSet.get(province.getId());
 			
 			Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
 			Color fillColor = new Color(province.getFillColour(), (float) province.getFillOpacity());
@@ -188,7 +188,6 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 				shapeMarker.setLineColor(borderColor);
 				shapeMarker.setFillColor(fillColor);
 			}
-			borderMarkerSet.put(province.getId(), marker);
 		}
 	}
 

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -164,25 +164,36 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 	protected void setProvinceMapStyles() {
 		Marker marker;
 		for(Province province : new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())){
-			marker = borderMarkerSet.get(province.getId());
+			TownyProvinces.info("DEBUG: Province marker " + province.getId() + " being styled");
+			marker = borderMarkerSet.remove(province.getId());
+			
+			Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
+			Color fillColor = new Color(province.getFillColour(), (float) province.getFillOpacity());
+			
+			if (marker == null) {
+				TownyProvinces.severe("ERROR: Province marker for styling is null");
+				continue;
+			}
+			
+			if (marker instanceof ShapeMarker) {
+				TownyProvinces.info("DEBUG: Province marker is a ShapeMarker");
+				ShapeMarker shapeMarker = (ShapeMarker) marker;
+				if(!shapeMarker.getLineColor().equals(borderColor)){
+					TownyProvinces.info("DEBUG: Line color does not match");
+					shapeMarker.setLineColor(borderColor);
+				}
 
-			float borderOpacity = (float) province.getType().getBorderOpacity();
-			float fillOpacity = (float) province.getFillOpacity();
-			java.awt.Color borderColor = new java.awt.Color(province.getType().getBorderColour());
-			Color color = new Color(borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue(), borderOpacity);
-			java.awt.Color fillColor = new java.awt.Color(province.getFillColour());
-			Color color1 = new Color(fillColor.getRed(), fillColor.getGreen(), fillColor.getBlue(), fillOpacity);
-			if(marker != null){
-			  if(marker instanceof ShapeMarker){
-					if(!((ShapeMarker) marker).getLineColor().equals(color)){
-						((ShapeMarker) marker).setLineColor(color);
-					}
-					
-					if(!((ShapeMarker) marker).getFillColor().equals(color1)){
-						((ShapeMarker) marker).setFillColor(color1);
-					}
+				if (fillColor.getRed() != 0 || fillColor.getGreen() != 0 || fillColor.getBlue() != 0) {
+					TownyProvinces.info("DEBUG: Fill color is " + shapeMarker.getFillColor().toString());
+					TownyProvinces.info("DEBUG: It should be " + fillColor);
+				}
+				if(!shapeMarker.getFillColor().equals(fillColor)){
+					TownyProvinces.info("DEBUG: Fill color does not match");
+					shapeMarker.setFillColor(fillColor);
 				}
 			}
+			TownyProvinces.info("DEBUG: Adding the marker back");
+			borderMarkerSet.put(province.getId(), marker);
 		}
 	}
 

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -218,12 +218,8 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 	}
 
 	private void drawBorderLine(List<TPCoord> drawableLineOfBorderCoords, Province province, String markerId) {
-		float borderOpacity = (float) province.getType().getBorderOpacity();
-		float fillOpacity = (float) province.getFillOpacity();
-		java.awt.Color borderColor = new java.awt.Color(province.getType().getBorderColour());
-		Color color = new Color(borderColor.getRed(), borderColor.getGreen(), borderColor.getBlue(), borderOpacity);
-		java.awt.Color fillColor = new java.awt.Color(province.getFillColour());
-		Color color1 = new Color(fillColor.getRed(), fillColor.getGreen(), fillColor.getBlue(), fillOpacity);
+		Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
+		Color fillColor = new Color(province.getFillColour(), (float) province.getFillOpacity());
 		List<Vector2d> points = new ArrayList<>();
 		for(TPCoord drawableLineOfBorderCoord : drawableLineOfBorderCoords){
 			int x = (drawableLineOfBorderCoord.getX() * TownyProvincesSettings.getChunkSideLength());
@@ -247,8 +243,8 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 		Shape shape = new Shape(points);
 		ShapeMarker marker = ShapeMarker.builder()
 			.shape(shape, 65)
-			.fillColor(color1)
-			.lineColor(color)
+			.fillColor(fillColor)
+			.lineColor(borderColor)
 			.label(province.getId())
 			.depthTestEnabled(false)
 			.build();

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -174,7 +174,8 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 		Marker marker;
 		for(Province province : new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())){
 			marker = borderMarkerSet.get(province.getId());
-			
+
+			int borderWeight = province.getType().getBorderWeight();
 			Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
 			Color fillColor = new Color(province.getFillColour(), (float) province.getFillOpacity());
 			
@@ -186,6 +187,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 			if (marker instanceof ShapeMarker) {
 				ShapeMarker shapeMarker = (ShapeMarker) marker;
 				shapeMarker.setLineColor(borderColor);
+				shapeMarker.setLineWidth(borderWeight);
 				shapeMarker.setFillColor(fillColor);
 			}
 		}
@@ -193,6 +195,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 
 	@Override
 	protected void drawProvinceBorder(Province province) {
+		int borderWeight = province.getType().getBorderWeight();
 		Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
 		String markerId = province.getId();
 		Marker marker = borderMarkerSet.get(markerId);
@@ -213,10 +216,12 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 		if (marker instanceof ShapeMarker) {
 			ShapeMarker shapeMarker = (ShapeMarker) marker;
 			shapeMarker.setLineColor(borderColor);
+			shapeMarker.setLineWidth(borderWeight);
 		}
 	}
 
 	private void drawBorderLine(List<TPCoord> drawableLineOfBorderCoords, Province province, String markerId) {
+		int borderWeight = province.getType().getBorderWeight();
 		Color borderColor = new Color(province.getType().getBorderColour(), (float) province.getType().getBorderOpacity());
 		Color fillColor = new Color(province.getFillColour(), (float) province.getFillOpacity());
 		List<Vector2d> points = new ArrayList<>();
@@ -244,6 +249,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 			.shape(shape, 65)
 			.fillColor(fillColor)
 			.lineColor(borderColor)
+			.lineWidth(borderWeight)
 			.label(province.getId())
 			.depthTestEnabled(false)
 			.build();


### PR DESCRIPTION
Fixes
- BlueMap provinces did not update with new Border colour during Land Validation
- BlueMap provinces did not update with new Fill colour during Nation colour change
- BlueMap provinces were not setting or updating border weight 
- Fixes one point where Color is compared to int

Cleans up
- Simplifies use of BlueMap Color by using a constructor to directly take int & opacity
- Removes redundant checks of Color equality (this will be done in other maps in separate PR)