### PR TITLE
Clean up and throw exceptions in Map actions

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -112,40 +112,47 @@ public class TownyProvinces extends JavaPlugin {
 	}
 	
 	private boolean loadIntegrations() {
-		try {
-			if (getServer().getPluginManager().isPluginEnabled("Pl3xMap")) {
+		if (getServer().getPluginManager().isPluginEnabled("Pl3xMap")) {
+			try {
 				if (classExists("net.pl3x.map.core.Pl3xMap")) {
 					info("Found Pl3xMap v3. Enabling Pl3xMap integration.");
 					MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnPl3xMapV3Action());
-				}
-				else if (classExists("net.pl3x.map.Pl3xMap")) {
+				} else if (classExists("net.pl3x.map.Pl3xMap")) {
 					//Pl3xMap v2
 					info("Pl3xMap v2 is not supported. Cannot enable Pl3xMap integration.");
-				}
-				else {
+				} else {
 					//Pl3xMap v1
 					info("Pl3xMap v1 is not supported. Cannot enable Pl3xMap integration.");
 				}
+			} catch (RuntimeException e) {
+				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling Pl3xMap integration: " + e.getMessage());
+				e.printStackTrace();
 			}
-			if(getServer().getPluginManager().isPluginEnabled("bluemap")){
+		}
+		if(getServer().getPluginManager().isPluginEnabled("bluemap")){
+			try {
 				info("Found BlueMap. Enabling BlueMap integration.");
 				MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnBlueMapAction());
+			} catch (RuntimeException e) {
+				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling BlueMap integration: " + e.getMessage());
+				e.printStackTrace();
 			}
-			if (getServer().getPluginManager().isPluginEnabled("dynmap")) {
+		}
+		if (getServer().getPluginManager().isPluginEnabled("dynmap")) {
+			try {
 				info("Found Dynmap plugin. Enabling Dynmap integration.");
 				MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnDynmapAction());
+			} catch (RuntimeException e) {
+				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling Dynmap integration: " + e.getMessage());
+				e.printStackTrace();
 			}
-			if (!MapDisplayTaskController.isMapSupported()) {
-				info("Did not find a supported map plugin. Cannot enable map integration.");
-				return false;
-			}
-			MapDisplayTaskController.startTask();
-			return true;
-		} catch (Exception e) {
-			Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling map integration: " + e.getMessage());
-			e.printStackTrace();
+		}
+		if (!MapDisplayTaskController.isMapSupported()) {
+			info("Did not find a supported map plugin. Cannot enable map integration.");
 			return false;
 		}
+		MapDisplayTaskController.startTask();
+		return true;
 	}
 	
 	private boolean checkTownyVersion() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -32,14 +32,13 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 	private MarkerSet homeBlocksMarkersSet;
 	private final TPFreeCoord tpFreeCoord;
 	
-	public DisplayProvincesOnBlueMapAction(){
+	public DisplayProvincesOnBlueMapAction() {
 		TownyProvinces.info("Enabling BlueMap support.");
 
 		tpFreeCoord = new TPFreeCoord(0,0);
-		
+
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support BlueMap.");
-			return;
+			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
 		}
 		
 		BlueMapAPI.onEnable(e -> {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -249,11 +249,11 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 		//Cycle provinces
 		AreaMarker areaMarker;
 		for(Province province: new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())) {
-			//Set border colour if needed
+			//Set border colour
 			areaMarker = bordersMarkerSet.findAreaMarker(province.getId());
 			if(areaMarker != null) {
 				areaMarker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
-				//Set fill colour if needed
+				//Set fill colour
 				areaMarker.setFillStyle(province.getFillOpacity(), province.getFillColour());
 			}
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -8,6 +8,7 @@ import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+import net.pl3x.map.core.image.io.IO;
 import org.dynmap.DynmapAPI;
 import org.dynmap.markers.AreaMarker;
 import org.dynmap.markers.Marker;
@@ -38,8 +39,7 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 		tpFreeCoord = new TPFreeCoord(0,0);
 
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Dynmap.");
-			return;
+			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
 		}
 		
 		final MarkerIcon oldMarkerIcon = markerapi.getMarkerIcon("provinces_costs_icon");
@@ -50,16 +50,16 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		try {
 			ImageIO.write(TownyProvincesSettings.getTownCostsIcon(), "png", outputStream);
-		} catch (IOException e) {
-			e.printStackTrace();
-			return;
+		} catch (IOException ex) {
+			TownyProvinces.severe("Failed to write BlueMap Marker Icon as png file!");
+			throw new RuntimeException(ex);
 		}
 		ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
 		MarkerIcon markerIcon = markerapi.createMarkerIcon("provinces_costs_icon",
 			"provinces_costs_icon", inputStream);
 
 		if (markerIcon == null) {
-			TownyProvinces.severe("Error registering Town Costs Icon on Dynmap! Unable to support Dynmap.");
+			throw new RuntimeException("Failed to register Town Costs Icon");
 		}
 		TownyProvinces.info("Dynmap support enabled.");
 	}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -8,7 +8,6 @@ import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
-import net.pl3x.map.core.image.io.IO;
 import org.dynmap.DynmapAPI;
 import org.dynmap.markers.AreaMarker;
 import org.dynmap.markers.Marker;
@@ -181,10 +180,7 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 			}
 		} else {
 			//Re-evaluate province border colour
-			if (marker.getLineColor() != province.getType().getBorderColour()) {
-				//Change colour of marker
-				marker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
-			}
+			marker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
 		} 
 	}
 
@@ -256,13 +252,9 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 			//Set border colour if needed
 			areaMarker = bordersMarkerSet.findAreaMarker(province.getId());
 			if(areaMarker != null) {
-				if (areaMarker.getLineColor() != province.getType().getBorderColour()) {
-					areaMarker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
-				}
+				areaMarker.setLineStyle(province.getType().getBorderWeight(), province.getType().getBorderOpacity(), province.getType().getBorderColour());
 				//Set fill colour if needed
-				if (areaMarker.getFillOpacity() != province.getFillOpacity() || areaMarker.getFillColor() != province.getFillColour()) {
-					areaMarker.setFillStyle(province.getFillOpacity(), province.getFillColour());
-				}
+				areaMarker.setFillStyle(province.getFillOpacity(), province.getFillColour());
 			}
 		}
 	}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -21,7 +21,6 @@ import net.pl3x.map.core.markers.option.Options;
 import net.pl3x.map.core.markers.option.Stroke;
 import net.pl3x.map.core.world.World;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
@@ -195,16 +194,9 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 				return;
 			}
 			Stroke stroke = polyLineMarker.getOptions().getStroke();
-			if (stroke.getColor() == null) {
-				TownyProvinces.severe("WARNING: Marker stroke color is null for province border marker " + markerId + ".");
-				return;
-			}
 			//Re-evaluate colour
-			if (!stroke.getColor().equals(borderColour)) {
-				//Change colour of marker
-				stroke.setColor(borderColour);
-				stroke.setWeight(borderWeight);
-			}
+			stroke.setColor(borderColour);
+			stroke.setWeight(borderWeight);
 		} 
 	}
 
@@ -322,20 +314,16 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 				TownyProvinces.severe("WARNING: Marker fill color is null for province border marker " + markerId + ".");
 				continue;
 			}
-			//Set border colour if needed
+			//Set border colour
 			requiredBorderColour = province.getType().getBorderColour() |
 				(int) (255 * province.getType().getBorderOpacity()) << 24;
 			requiredBorderWeight = province.getType().getBorderWeight();
-			if (stroke.getColor() != requiredBorderColour) {
-				stroke.setColor(requiredBorderColour);
-				stroke.setWeight(requiredBorderWeight);
-			}
-			//Set fill colour if needed
+			stroke.setColor(requiredBorderColour);
+			stroke.setWeight(requiredBorderWeight);
+			//Set fill colour
 			requiredFillColour = province.getFillColour() |
 				(int) (255 * province.getFillOpacity()) << 24;
-			if (fill.getColor() != requiredFillColour) {
-				fill.setColor(requiredFillColour);
-			}
+			fill.setColor(requiredFillColour);
 		}
 	}
 }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -21,6 +21,7 @@ import net.pl3x.map.core.markers.option.Options;
 import net.pl3x.map.core.markers.option.Stroke;
 import net.pl3x.map.core.world.World;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
@@ -34,10 +35,9 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 	public DisplayProvincesOnPl3xMapV3Action() {
 		TownyProvinces.info("Enabling Pl3xMap v3 support.");
 		tpFreeCoord = new TPFreeCoord(0,0);
-		
+
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Pl3xMap V3.");
-			return;
+			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
 		}
 
 		Pl3xMap.api().getIconRegistry().register(new IconImage(


### PR DESCRIPTION
This is a very opinionated PR that you may not agree with entirely

Changes:

- Throw RuntimeException in any MapAction constructor if Town Costs Icon URL is invalid or it does not register (for Dynmap; even if it would not be used - felt this was a nonissue)
- Remove equality checks before setting Marker colour in Pl3xMap v3 and Dynmap actions (in BlueMap this is in the other PR as it was part of that first)
- Catch RuntimeException on a per-map basis in TownyProvinces, do not catch any other Exception (Makes a clear divide between intended and unintended exceptions which I felt should be allowed to propagate)