### PR TITLE
Webmap integration reloading fixes

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -102,7 +102,7 @@ public class TownyProvinces extends JavaPlugin {
 		}
 
 		//Refresh 
-		MapDisplayTaskController.requestFullMapRefresh();
+		MapDisplayTaskController.reloadIntegrations();
 		info("TownyProvinces Reloaded Successfully");
 	}
 

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -37,7 +37,9 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 
 		tpFreeCoord = new TPFreeCoord(0,0);
 		
-		BlueMapAPI.onEnable(e -> reloadAction());
+		BlueMapAPI.onEnable(e -> {
+			reloadAction();
+		});
 		
 		TownyProvinces.info("BlueMap support enabled.");
 	  }

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -37,7 +37,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 
 		tpFreeCoord = new TPFreeCoord(0,0);
 		
-		reloadAction();
+		BlueMapAPI.onEnable(e -> reloadAction());
 		
 		TownyProvinces.info("BlueMap support enabled.");
 	  }
@@ -49,7 +49,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
 		}
 
-		BlueMapAPI.onEnable(e -> {
+		BlueMapAPI.getInstance().ifPresent(e -> {
 			Path assetsFolder = e.getWebApp().getWebRoot().resolve("assets");
 			try (OutputStream out = Files.newOutputStream(assetsFolder.resolve("province.png"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
 				BufferedImage configIcon = TownyProvincesSettings.getTownCostsIcon();
@@ -73,7 +73,7 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 	  
 	@Override
 	void executeAction(boolean bordersRefreshRequested, boolean homeBlocksRefreshRequested) {
-		BlueMapAPI.getInstance().ifPresent( api -> {
+		BlueMapAPI.getInstance().ifPresent(api -> {
 			Optional<BlueMapWorld> world = api.getWorld(TownyProvincesSettings.getWorld());
 			homeBlocksMarkersSet = MarkerSet.builder()
 				.label("TownyProvinces - Town Costs")

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnBlueMapAction.java
@@ -37,11 +37,18 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 
 		tpFreeCoord = new TPFreeCoord(0,0);
 		
+		reloadAction();
+		
+		TownyProvinces.info("BlueMap support enabled.");
+	  }
+	  
+	@Override
+	void reloadAction() {
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
 			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support BlueMap.");
 			return;
 		}
-		
+
 		BlueMapAPI.onEnable(e -> {
 			Path assetsFolder = e.getWebApp().getWebRoot().resolve("assets");
 			try (OutputStream out = Files.newOutputStream(assetsFolder.resolve("province.png"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
@@ -54,16 +61,15 @@ public class DisplayProvincesOnBlueMapAction extends DisplayProvincesOnMapAction
 				Graphics2D g2d = resizedIcon.createGraphics();
 				g2d.drawImage(configIcon, 0, 0, TownyProvincesSettings.getTownCostsIconWidth(), TownyProvincesSettings.getTownCostsIconHeight(), null);
 				g2d.dispose();
-				
+
 				ImageIO.write(resizedIcon, "png", out);
 			} catch (IOException ex) {
 				TownyProvinces.severe("Failed to put BlueMap Marker Icon as png file!");
 				throw new RuntimeException(ex);
 			}
 		});
-		
-		TownyProvinces.info("BlueMap support enabled.");
-	  }
+	}
+	  
 	  
 	@Override
 	void executeAction(boolean bordersRefreshRequested, boolean homeBlocksRefreshRequested) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -33,15 +33,23 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 
 	public DisplayProvincesOnDynmapAction() {
 		TownyProvinces.info("Enabling dynmap support.");
+		
 		DynmapAPI dynmapAPI = (DynmapAPI) TownyProvinces.getPlugin().getServer().getPluginManager().getPlugin("dynmap");
 		markerapi = dynmapAPI.getMarkerAPI();
 		tpFreeCoord = new TPFreeCoord(0,0);
 
+		reloadAction();
+		
+		TownyProvinces.info("Dynmap support enabled.");
+	}
+	
+	@Override
+	void reloadAction() {
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
 			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Dynmap.");
 			return;
 		}
-		
+
 		final MarkerIcon oldMarkerIcon = markerapi.getMarkerIcon("provinces_costs_icon");
 		if (oldMarkerIcon != null) {
 			oldMarkerIcon.deleteIcon();
@@ -61,7 +69,6 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 		if (markerIcon == null) {
 			TownyProvinces.severe("Error registering Town Costs Icon on Dynmap! Unable to support Dynmap.");
 		}
-		TownyProvinces.info("Dynmap support enabled.");
 	}
 	
 	@Override

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnDynmapAction.java
@@ -108,9 +108,10 @@ public class DisplayProvincesOnDynmapAction extends DisplayProvincesOnMapAction 
 		MarkerSet markerSet = markerapi.getMarkerSet(markerSetId);
 		if (markerSet == null) {
 			markerSet = markerapi.createMarkerSet(markerSetId, markerSetName, null, false);
-			markerSet.setHideByDefault(hideByDefault);
-			markerSet.setLabelShow(labelShow);
 		}
+
+		markerSet.setHideByDefault(hideByDefault);
+		markerSet.setLabelShow(labelShow);
 
 		if (markerSet == null) {
 			TownyProvinces.severe("Error creating Dynmap marker set!");

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnMapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnMapAction.java
@@ -19,6 +19,8 @@ public abstract class DisplayProvincesOnMapAction {
 	 * Display all TownyProvinces items
 	 */
 	abstract void executeAction(boolean bordersRefreshRequested, boolean homeBlocksRefreshRequested);
+	
+	abstract void reloadAction();
 
 	abstract protected void drawProvinceHomeBlocks();
 

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -33,15 +33,10 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 
 	public DisplayProvincesOnPl3xMapV3Action() {
 		TownyProvinces.info("Enabling Pl3xMap v3 support.");
+		
 		tpFreeCoord = new TPFreeCoord(0,0);
 		
-		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Pl3xMap V3.");
-			return;
-		}
-
-		Pl3xMap.api().getIconRegistry().register(new IconImage(
-			"provinces_costs_icon", TownyProvincesSettings.getTownCostsIcon(), "png"));
+		reloadAction();
 		
 		TownyProvinces.info("Pl3xMap v3 support enabled.");
 	}
@@ -106,6 +101,17 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 		world.getLayerRegistry().register(layer);
 
 		return layer;
+	}
+	
+	@Override
+	void reloadAction() {
+		if (TownyProvincesSettings.getTownCostsIcon() == null) {
+			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Pl3xMap V3.");
+			return;
+		}
+
+		Pl3xMap.api().getIconRegistry().register(new IconImage(
+			"provinces_costs_icon", TownyProvincesSettings.getTownCostsIcon(), "png"));
 	}
 	
 	@Override

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -9,6 +9,10 @@ import io.github.townyadvanced.townyprovinces.objects.TPCoord;
 import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.event.EventHandler;
+import net.pl3x.map.core.event.EventListener;
+import net.pl3x.map.core.event.server.Pl3xMapEnabledEvent;
+import net.pl3x.map.core.event.world.WorldLoadedEvent;
 import net.pl3x.map.core.image.IconImage;
 import net.pl3x.map.core.markers.Point;
 import net.pl3x.map.core.markers.layer.Layer;
@@ -25,7 +29,7 @@ import net.pl3x.map.core.world.World;
 import java.util.*;
 import java.util.List;
 
-public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapAction {
+public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapAction implements EventListener {
 	
 	private SimpleLayer bordersLayer;
 	private SimpleLayer homeBlocksLayer;
@@ -38,8 +42,24 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 		tpFreeCoord = new TPFreeCoord(0,0);
 		
 		reloadAction();
+
+		Pl3xMap.api().getEventRegistry().register(this);
 		
 		TownyProvinces.info("Pl3xMap v3 support enabled.");
+	}
+
+	@EventHandler
+	public void onPl3xMapEnabled(Pl3xMapEnabledEvent event) {
+		reloadAction();
+	}
+	
+	@EventHandler
+	public void onPl3xMapWorldLoaded(WorldLoadedEvent event) {
+		if (event.getWorld().getName().equals(TownyProvincesSettings.getWorldName())) {
+			world = event.getWorld();
+			world.getLayerRegistry().register(homeBlocksLayer);
+			world.getLayerRegistry().register(bordersLayer);
+		}
 	}
 
 	/**
@@ -86,8 +106,8 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 	
 	private SimpleLayer createLayer(String layerKey, String layerName, boolean hideByDefault, int priority, int zIndex, boolean showControls) {
 		//Create simple layer
-		Layer layer = world.getLayerRegistry().get(layerKey);
 		SimpleLayer simpleLayer = null;
+		Layer layer = world.getLayerRegistry().get(layerKey);
 		if (layer instanceof SimpleLayer) {
 			simpleLayer = (SimpleLayer) layer;
 		}
@@ -101,7 +121,7 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 		simpleLayer.setPriority(priority);
 		simpleLayer.setZIndex(zIndex);
 		simpleLayer.setShowControls(showControls);
-
+		
 		return simpleLayer;
 	}
 	

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnPl3xMapV3Action.java
@@ -11,6 +11,7 @@ import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import net.pl3x.map.core.Pl3xMap;
 import net.pl3x.map.core.image.IconImage;
 import net.pl3x.map.core.markers.Point;
+import net.pl3x.map.core.markers.layer.Layer;
 import net.pl3x.map.core.markers.layer.SimpleLayer;
 import net.pl3x.map.core.markers.marker.Icon;
 import net.pl3x.map.core.markers.marker.Marker;
@@ -51,16 +52,13 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 			return;
 		}
 		
-		bordersLayer = (SimpleLayer) world.getLayerRegistry().get("townyprovinces.layer.borders");
-		homeBlocksLayer = (SimpleLayer) world.getLayerRegistry().get("townyprovinces.layer.homeblocks");
-		
-		if(bordersRefreshRequested) {
+		if (bordersRefreshRequested) {
 			if(bordersLayer != null) {
 				bordersLayer.clearMarkers();
 			}
 			addProvinceBordersLayer();
 		}
-		if(homeBlocksRefreshRequested) {
+		if (homeBlocksRefreshRequested) {
 			if(homeBlocksLayer != null) {
 				homeBlocksLayer.clearMarkers();
 			}
@@ -88,19 +86,23 @@ public class DisplayProvincesOnPl3xMapV3Action extends DisplayProvincesOnMapActi
 	
 	private SimpleLayer createLayer(String layerKey, String layerName, boolean hideByDefault, int priority, int zIndex, boolean showControls) {
 		//Create simple layer
-		if (world.getLayerRegistry().get(layerKey) != null)
-			return (SimpleLayer)world.getLayerRegistry().get(layerKey);
+		Layer layer = world.getLayerRegistry().get(layerKey);
+		SimpleLayer simpleLayer = null;
+		if (layer instanceof SimpleLayer) {
+			simpleLayer = (SimpleLayer) layer;
+		}
 		
-		SimpleLayer layer = new SimpleLayer(layerKey, layerName::toString);
+		if (simpleLayer == null) {
+			simpleLayer = new SimpleLayer(layerKey, layerName::toString);
+			world.getLayerRegistry().register(simpleLayer);
+		}
 
-		layer.setDefaultHidden(hideByDefault);
-		layer.setPriority(priority);
-		layer.setZIndex(zIndex);
-		layer.setShowControls(showControls);
+		simpleLayer.setDefaultHidden(hideByDefault);
+		simpleLayer.setPriority(priority);
+		simpleLayer.setZIndex(zIndex);
+		simpleLayer.setShowControls(showControls);
 
-		world.getLayerRegistry().register(layer);
-
-		return layer;
+		return simpleLayer;
 	}
 	
 	@Override

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
@@ -37,9 +37,9 @@ public class MapDisplayTaskController {
 				}
 			}
 		}
-		mapDisplayTask.runTaskTimerAsynchronously(TownyProvinces.getPlugin(), 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
-		
 		requestFullMapRefresh();
+		mapDisplayTask = new MapDisplayTask();
+		mapDisplayTask.runTaskTimerAsynchronously(TownyProvinces.getPlugin(), 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
 	}
 
 	public static void requestFullMapRefresh() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
@@ -1,16 +1,9 @@
 package io.github.townyadvanced.townyprovinces.jobs.map_display;
-import com.palmergames.bukkit.towny.object.Nation;
-import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.WorldCoord;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
-import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
-import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class MapDisplayTaskController {
 	private static final List<DisplayProvincesOnMapAction> mapDisplayActions = new ArrayList<>();
@@ -30,6 +23,23 @@ public class MapDisplayTaskController {
 			TownyProvinces.info("Map Display Job Started");
 			return true;
 		}
+	}
+	
+	public static void reloadIntegrations() {
+		
+		mapDisplayTask.cancel();
+		synchronized (TownyProvinces.MAP_DISPLAY_JOB_LOCK) {
+			synchronized (TownyProvinces.REGION_REGENERATION_JOB_LOCK) {
+				synchronized (TownyProvinces.PRICE_RECALCULATION_JOB_LOCK) {
+					for (DisplayProvincesOnMapAction mapDisplayAction : getMapDisplayActions()) {
+						mapDisplayAction.reloadAction();
+					}
+				}
+			}
+		}
+		mapDisplayTask.runTaskTimerAsynchronously(TownyProvinces.getPlugin(), 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
+		
+		requestFullMapRefresh();
 	}
 
 	public static void requestFullMapRefresh() {


### PR DESCRIPTION
Fixes:
- Reloading BlueMap or Pl3xMap with their command
- Changing Map Refresh period when reloading with /tpra
- Changing Town Costs icon when reloading with /tpra
- Changing whether Dynmap uses this icon when reloading
- Modifying Pl3xMap layer attributes

Changes:
- Throws RuntimeException when invalid Town Costs icon (Even if it is not used in Dynmap for simplicity/parity)
- Remove equality checks before setting Marker colour in Pl3xMap v3 and Dynmap
- Catch RuntimeException on a per-map basis in TownyProvinces, do not catch any other Exception