### PR TITLE
Fixes issue loading not-present Mapper plugins on Spigot-using server.

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -9,10 +9,7 @@ import com.palmergames.bukkit.util.Version;
 import io.github.townyadvanced.townyprovinces.commands.TownyProvincesAdminCommand;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnBlueMapAction;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnDynmapAction;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnPl3xMapV3Action;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.MapDisplayTaskController;
+import io.github.townyadvanced.townyprovinces.jobs.map_display.*;
 import io.github.townyadvanced.townyprovinces.listeners.TownyListener;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 import io.github.townyadvanced.townyprovinces.settings.Settings;
@@ -116,7 +113,13 @@ public class TownyProvinces extends JavaPlugin {
 			try {
 				if (classExists("net.pl3x.map.core.Pl3xMap")) {
 					info("Found Pl3xMap v3. Enabling Pl3xMap integration.");
-					MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnPl3xMapV3Action());
+					try {
+						Class<?> mapClass = Class.forName("io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnPl3xMapV3Action");
+						MapDisplayTaskController.addMapDisplayAction((DisplayProvincesOnMapAction) mapClass.getConstructor().newInstance());
+					} catch (ReflectiveOperationException e) {
+						Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem loading Pl3xMap integration: " + e.getMessage());
+						e.printStackTrace();
+					}
 				} else if (classExists("net.pl3x.map.Pl3xMap")) {
 					//Pl3xMap v2
 					info("Pl3xMap v2 is not supported. Cannot enable Pl3xMap integration.");
@@ -132,7 +135,13 @@ public class TownyProvinces extends JavaPlugin {
 		if(getServer().getPluginManager().isPluginEnabled("bluemap")){
 			try {
 				info("Found BlueMap. Enabling BlueMap integration.");
-				MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnBlueMapAction());
+				try {
+					Class<?> mapClass = Class.forName("io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnBlueMapAction");
+					MapDisplayTaskController.addMapDisplayAction((DisplayProvincesOnMapAction) mapClass.getConstructor().newInstance());
+				} catch (ReflectiveOperationException e) {
+					Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem loading BlueMap integration: " + e.getMessage());
+					e.printStackTrace();
+				}
 			} catch (RuntimeException e) {
 				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling BlueMap integration: " + e.getMessage());
 				e.printStackTrace();
@@ -141,7 +150,13 @@ public class TownyProvinces extends JavaPlugin {
 		if (getServer().getPluginManager().isPluginEnabled("dynmap")) {
 			try {
 				info("Found Dynmap plugin. Enabling Dynmap integration.");
-				MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnDynmapAction());
+				try {
+					Class<?> mapClass = Class.forName("io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnDynmapAction");
+					MapDisplayTaskController.addMapDisplayAction((DisplayProvincesOnMapAction) mapClass.getConstructor().newInstance());
+				} catch (ReflectiveOperationException e) {
+					Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem loading Dynmap integration: " + e.getMessage());
+					e.printStackTrace();
+				}
 			} catch (RuntimeException e) {
 				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling Dynmap integration: " + e.getMessage());
 				e.printStackTrace();

--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -132,7 +132,7 @@ public class TownyProvinces extends JavaPlugin {
 				e.printStackTrace();
 			}
 		}
-		if(getServer().getPluginManager().isPluginEnabled("bluemap")){
+		if(getServer().getPluginManager().isPluginEnabled("BlueMap")){
 			try {
 				info("Found BlueMap. Enabling BlueMap integration.");
 				try {


### PR DESCRIPTION
These were not issues in Paper with Modern Plugin Loading Strategy, but they were issues in Spigot and Paper with Legacy Plugin Loading Strategy

Essentially it seems Modern loading does not verify interfaces exist if the class is not instantiated, but Legacy loading does. I don't have an explanation for this but it is resolved in this PR

Tested on Spigot, Paper w/ Legacy and Paper w/ Modern

Additionally I noticed BlueMap support did not load on Spigot as it appears to be case-sensitive there; this may be a local issue but this is resolved here with no adverse effects to the people it did work for.