### PR TITLE
Squaremap Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 - `tpra province settype [civilized|sea|wasteland] [<x1>,<z1>] [<2x>,<z2>]` -> Set the type of all provinces in a rectangular area.
 - `tpra region [newtowncostperchunk] [<Region Name>] [amount]` -> Set the per-chunk new-town-cost for a region.
 - `tpra region [upkeeptowncostperchunk] [<Region Name>] [amount]` -> Set the per-chunk upkeep-town-cost for a region.
-- `tpra reload -> Reload Config and Language files, and refresh map.
+- `tpra reload` -> Reload Config and Language files, and refresh map.
 
 ## :brain: Advanced Guide to Region Definitions
 To fully understand how to configure your region definition files, you must understand how provinces are generated:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## :information_source: Overview
 - :world_map: An add-on plugin for *Towny*, which makes claiming more organized, reducing staff workload and server toxicity.
-  
+
 ## :gift: Features
 - :globe_with_meridians: **Divides The Map Automatically into Provinces:**
   - :tophat: Civilised Provinces: 1 town only, no foreign outposts allowed.
@@ -25,11 +25,11 @@
 
 ## :floppy_disk: Installation Guide
 1. Ensure your server has *Towny 0.99.1.0* or newer.
-2. Ensure your server has a map-display plugin: Either *Dynmap*, *Pl3xmap* or *BlueMap*.
+2. Ensure your server has a map-display plugin: Either *Dynmap*, *Pl3xMap*, *BlueMap* or *squaremap*.
 3. Download the *TownyProvinces* plugin jar file from [here](https://github.com/TownyAdvanced/TownyProvinces/releases), and drop it into your server plugins folder.
 4. Stop your server.
 5. Start your server with plenty of memory (*especially for big maps*).
-   - Example: With Spigot you might run: `java -Xms1G -Xmx3G -XX:+UseG1GC -jar spigot-1.19.4.jar nogui`.
+   - Example: With Spigot you might run: `java -Xms1G -Xmx3G -XX:+UseG1GC -jar spigot-1.20.4.jar nogui`.
 
 ## :football: Player Guide
 - :cityscape: Towns:
@@ -42,7 +42,7 @@
 
 ## :fast_forward: Admin Quick-Start Guide
 1. Run `tpra region regenerate all`. This will generate 2 small sample regions.
-2. To see the generated provinces, view your website-map. 
+2. To see the generated provinces, view your website-map.
 
 ## :arrow_forward: Admin Full Guide
 1. Protect Historical Town Locations
@@ -65,7 +65,7 @@
 - `tpra region [regenerate] [<Region Name>]` -> Regenerate a region.
 - `tpra landvalidationjob [status|start|stop|restart|pause]` -> Control the land validation job.
   - This Job assigns a type to each provinces, either Civilized, Sea, or Wasteland. It also Assesses and records the Biome proportions in each province. These proportions affect the new/upkeep prices.
-  - *NOTE: The automatic validation is not perfect, so expect to convert a few provinces afterwards using the below commands.* 
+  - *NOTE: The automatic validation is not perfect, so expect to convert a few provinces afterwards using the below commands.*
 - `tpra province settype [civilized|sea|wasteland] [<x>,<z>]` -> Set the type of a province.
 - `tpra province settype [civilized|sea|wasteland] [<x1>,<z1>] [<2x>,<z2>]` -> Set the type of all provinces in a rectangular area.
 - `tpra region [newtowncostperchunk] [<Region Name>] [amount]` -> Set the per-chunk new-town-cost for a region.

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
           <version>v2.5.1</version>
           <scope>provided</scope>
       </dependency>
+      <dependency>
+          <groupId>xyz.jpenilla</groupId>
+          <artifactId>squaremap-api</artifactId>
+          <version>1.1.12</version>
+          <scope>provided</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -9,10 +9,7 @@ import com.palmergames.bukkit.util.Version;
 import io.github.townyadvanced.townyprovinces.commands.TownyProvincesAdminCommand;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnBlueMapAction;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnDynmapAction;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.DisplayProvincesOnPl3xMapV3Action;
-import io.github.townyadvanced.townyprovinces.jobs.map_display.MapDisplayTaskController;
+import io.github.townyadvanced.townyprovinces.jobs.map_display.*;
 import io.github.townyadvanced.townyprovinces.listeners.TownyListener;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 import io.github.townyadvanced.townyprovinces.settings.Settings;
@@ -126,6 +123,10 @@ public class TownyProvinces extends JavaPlugin {
 					//Pl3xMap v1
 					info("Pl3xMap v1 is not supported. Cannot enable Pl3xMap integration.");
 				}
+			}
+			if (getServer().getPluginManager().isPluginEnabled("squaremap")) {
+				info("Found Squaremap. Enabling Squaremap integration.");
+				MapDisplayTaskController.addMapDisplayAction(new DisplayProvincesOnSquaremapAction());
 			}
 			if(getServer().getPluginManager().isPluginEnabled("bluemap")){
 				info("Found BlueMap. Enabling BlueMap integration.");

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
@@ -117,7 +117,8 @@ public class DisplayProvincesOnSquaremapAction extends DisplayProvincesOnMapActi
 		if (TownyProvincesSettings.getTownCostsIcon() == null) {
 			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
 		}
-
+		
+		if (api.iconRegistry().hasEntry(iconKey)) api.iconRegistry().unregister(iconKey);
 		api.iconRegistry().register(iconKey, TownyProvincesSettings.getTownCostsIcon());
 	}
 	

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
@@ -36,13 +36,8 @@ public class DisplayProvincesOnSquaremapAction extends DisplayProvincesOnMapActi
 		
 		api = SquaremapProvider.get();
 		tpFreeCoord = new TPFreeCoord(0,0);
-		
-		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Squaremap.");
-			return;
-		}
 
-		api.iconRegistry().register(iconKey, TownyProvincesSettings.getTownCostsIcon());
+		reloadAction();
 				
 		TownyProvinces.info("Squaremap support enabled.");
 	}
@@ -115,6 +110,15 @@ public class DisplayProvincesOnSquaremapAction extends DisplayProvincesOnMapActi
 		world.layerRegistry().register(layerKey, layer);
 
 		return layer;
+	}
+
+	@Override
+	void reloadAction() {
+		if (TownyProvincesSettings.getTownCostsIcon() == null) {
+			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
+		}
+
+		api.iconRegistry().register(iconKey, TownyProvincesSettings.getTownCostsIcon());
 	}
 	
 	@Override

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
@@ -1,0 +1,325 @@
+package io.github.townyadvanced.townyprovinces.jobs.map_display;
+
+import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.bukkit.towny.object.Translatable;
+import io.github.townyadvanced.townyprovinces.TownyProvinces;
+import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
+import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.objects.TPCoord;
+import io.github.townyadvanced.townyprovinces.objects.TPFreeCoord;
+import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import xyz.jpenilla.squaremap.api.*;
+import xyz.jpenilla.squaremap.api.Point;
+import xyz.jpenilla.squaremap.api.marker.Marker;
+import xyz.jpenilla.squaremap.api.marker.MarkerOptions;
+import xyz.jpenilla.squaremap.api.marker.Polygon;
+
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+
+public class DisplayProvincesOnSquaremapAction extends DisplayProvincesOnMapAction {
+	
+	private final Squaremap api;
+	private SimpleLayerProvider bordersLayer;
+	private SimpleLayerProvider homeBlocksLayer;
+	private final TPFreeCoord tpFreeCoord;
+	private final Key iconKey = Key.of("provinces_costs_icon");
+	private final Key bordersKey = Key.of("townyprovinces.markerset.borders");
+	private final Key homeBlocksKey = Key.of("townyprovinces.markerset.homeblocks");
+	private MapWorld world;
+
+	public DisplayProvincesOnSquaremapAction() {
+		TownyProvinces.info("Enabling Squaremap support.");
+		
+		api = SquaremapProvider.get();
+		tpFreeCoord = new TPFreeCoord(0,0);
+		
+		if (TownyProvincesSettings.getTownCostsIcon() == null) {
+			TownyProvinces.severe("Error: Town Costs Icon is not valid. Unable to support Squaremap.");
+			return;
+		}
+
+		api.iconRegistry().register(iconKey, TownyProvincesSettings.getTownCostsIcon());
+				
+		TownyProvinces.info("Squaremap support enabled.");
+	}
+
+	/**
+	 * Display all TownyProvinces items
+	 */
+	void executeAction(boolean bordersRefreshRequested, boolean homeBlocksRefreshRequested) {
+		World bukkitWorld = Bukkit.getWorld(TownyProvincesSettings.getWorldName());
+		if (bukkitWorld == null) {
+			TownyProvinces.severe("Configured world is not a valid world!");
+			return;
+		}
+		world = api.getWorldIfEnabled(BukkitAdapter.worldIdentifier(bukkitWorld)).orElse(null);
+		if (world == null) {
+			TownyProvinces.severe("World is not in Pl3xMap registry!");
+			return;
+		}
+		
+		if (world.layerRegistry().hasEntry(bordersKey))
+			bordersLayer = (SimpleLayerProvider) world.layerRegistry().get(bordersKey);
+		if (world.layerRegistry().hasEntry(homeBlocksKey))
+			homeBlocksLayer = (SimpleLayerProvider) world.layerRegistry().get(homeBlocksKey);
+		
+		if(bordersRefreshRequested) {
+			if(bordersLayer != null) {
+				bordersLayer.clearMarkers();
+			}
+			addProvinceBordersLayer();
+		}
+		if(homeBlocksRefreshRequested) {
+			if(homeBlocksLayer != null) {
+				homeBlocksLayer.clearMarkers();
+			}
+			addProvinceHomeBlocksLayer();
+		}
+		drawProvinceHomeBlocks();
+		drawProvinceBorders();
+	}
+	
+	private void addProvinceHomeBlocksLayer() {
+		String name = TownyProvinces.getPlugin().getName() + " - " + Translatable.of("dynmap_layer_label_town_costs").translate(Locale.ROOT);		
+		homeBlocksLayer = createLayer(homeBlocksKey, name, true, 
+			TownyProvincesSettings.getPl3xMapTownCostsLayerPriority(),
+			TownyProvincesSettings.getPl3xMapTownCostsLayerZIndex(),
+			true);
+	}
+
+	private void addProvinceBordersLayer() {
+		String name = TownyProvinces.getPlugin().getName() + " - " + Translatable.of("dynmap_layer_label_borders").translate(Locale.ROOT);
+		bordersLayer = createLayer(bordersKey, name, false, 
+			TownyProvincesSettings.getPl3xMapProvincesLayerPriority(), 
+			TownyProvincesSettings.getPl3xMapProvincesLayerZIndex(), 
+			TownyProvincesSettings.getPl3xMapProvincesLayerIsToggleable());
+	}
+	
+	private SimpleLayerProvider createLayer(Key layerKey, String layerName, boolean hideByDefault, int priority, int zIndex, boolean showControls) {
+		if (world.layerRegistry().hasEntry(layerKey)) {
+			//Existing simple layer
+			world.layerRegistry().unregister(layerKey);
+		}
+		//Create simple layer
+		SimpleLayerProvider layer = SimpleLayerProvider.builder(layerName)
+			.defaultHidden(hideByDefault)
+			.layerPriority(priority)
+			.zIndex(zIndex)
+			.showControls(showControls)
+			.build();
+
+		world.layerRegistry().register(layerKey, layer);
+
+		return layer;
+	}
+	
+	@Override
+	protected void drawProvinceHomeBlocks() {
+		boolean biomeCostAdjustmentsEnabled = TownyProvincesSettings.isBiomeCostAdjustmentsEnabled();
+		for (Province province : new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())) {
+			try {
+				TPCoord homeBlock = province.getHomeBlock();
+				Key homeBlockMarkerKey = Key.of("province_homeblock_" + homeBlock.getX() + "-" + homeBlock.getZ());
+				Marker homeBlockMarker = homeBlocksLayer.registeredMarkers().get(homeBlockMarkerKey);
+
+				if(province.getType().canNewTownsBeCreated()) {
+					//This is land If the marker is not there, we need to add it
+					if(homeBlockMarker != null)
+						continue;
+					int realHomeBlockX = homeBlock.getX() * TownyProvincesSettings.getChunkSideLength();
+					int realHomeBlockZ = homeBlock.getZ() * TownyProvincesSettings.getChunkSideLength();
+
+					String markerLabel;
+					if(TownyEconomyHandler.isActive()) {
+						int newTownCost = (int)(biomeCostAdjustmentsEnabled ? province.getBiomeAdjustedNewTownCost() : province.getNewTownCost());
+						String newTownCostString = TownyEconomyHandler.getFormattedBalance(newTownCost);
+						int upkeepTownCost = (int)(biomeCostAdjustmentsEnabled ? province.getBiomeAdjustedUpkeepTownCost() : province.getUpkeepTownCost());
+						String upkeepTownCostString = TownyEconomyHandler.getFormattedBalance(upkeepTownCost);
+						markerLabel = Translatable.of("dynmap_province_homeblock_label", newTownCostString, upkeepTownCostString).translate(Locale.ROOT);
+					} else {
+						markerLabel = "";
+					}
+					
+					homeBlockMarker = Marker.icon(
+						Point.of(realHomeBlockX, realHomeBlockZ),
+						iconKey,
+						TownyProvincesSettings.getTownCostsIconWidth(), 
+						TownyProvincesSettings.getTownCostsIconHeight());
+
+					MarkerOptions markerOptions = MarkerOptions.builder()
+						.clickTooltip(markerLabel)
+						.hoverTooltip(markerLabel)
+						.build();
+
+					homeBlockMarker.markerOptions(markerOptions);
+					
+					homeBlocksLayer.addMarker(homeBlockMarkerKey, homeBlockMarker);
+				} else {
+					//This is sea. If the marker is there, we need to remove it
+					if(homeBlockMarker == null)
+						continue;
+					homeBlocksLayer.removeMarker(homeBlockMarkerKey);
+					return;
+				}
+			} catch (Exception ex) {
+				TownyProvinces.severe("Problem adding homeblock marker");
+				ex.printStackTrace();
+			}
+		}
+	}
+	
+	@Override
+	protected void drawProvinceBorder(Province province) {
+		Color borderColor = new Color(province.getType().getBorderColour());
+		double borderOpacity = province.getType().getBorderOpacity();
+		int borderWeight = province.getType().getBorderWeight();
+		Key markerKey = Key.of(province.getId());
+		Marker polyLineMarker = bordersLayer.registeredMarkers().get(markerKey);
+		if(polyLineMarker == null) {
+			//Get border blocks
+			Set<TPCoord> borderCoords = findAllBorderCoords(province);
+			if(borderCoords.size() > 0) {
+				//Arrange border blocks into drawable line
+				List<TPCoord> drawableLineOfBorderCoords = arrangeBorderCoordsIntoDrawableLine(borderCoords);
+				
+				//Draw line
+				if(drawableLineOfBorderCoords.size() > 0) {
+					drawBorderLine(drawableLineOfBorderCoords, province, markerKey);
+				} else {
+					TownyProvinces.severe("WARNING: Could not arrange province coords into drawable line. If this message has not stopped repeating a few minutes after your server starts, please report it to TownyAdvanced.");
+				}
+			}
+		} else {
+			MarkerOptions oldOptions = polyLineMarker.markerOptions();
+			//Change colour of marker - Don't know why it can't be modified directly
+			MarkerOptions.Builder markerOptions = MarkerOptions.builder()
+				.stroke(oldOptions.stroke())
+				.strokeColor(borderColor)
+				.strokeWeight(borderWeight)
+				.strokeOpacity(borderOpacity)
+				.fill(oldOptions.fill())
+				.fillOpacity(oldOptions.fillOpacity())
+				.fillRule(oldOptions.fillRule())
+				.clickTooltip(oldOptions.clickTooltip())
+				.hoverTooltip(oldOptions.hoverTooltip());
+			if (oldOptions.fillColor() != null)
+				markerOptions.fillColor(oldOptions.fillColor());
+			polyLineMarker.markerOptions(markerOptions);
+		} 
+	}
+
+	private void drawBorderLine(List<TPCoord> drawableLineOfBorderCoords, Province province, Key markerKey) {
+		Color borderColor = new Color(province.getType().getBorderColour());
+		double borderOpacity = province.getType().getBorderOpacity();
+		int borderWeight = province.getType().getBorderWeight();
+
+		List<Point> points = new ArrayList<>();
+		for (TPCoord drawableLineOfBorderCoord : drawableLineOfBorderCoords) {
+			int x = (drawableLineOfBorderCoord.getX() * TownyProvincesSettings.getChunkSideLength());
+			int z = (drawableLineOfBorderCoord.getZ() * TownyProvincesSettings.getChunkSideLength());
+
+			/*
+			 * At this point,the draw location is at the top left of the block.
+			 * We need to move it towards the middle
+			 *
+			 * First we find the x,y pull strength from the nearby province
+			 *
+			 * Then we apply the following modifiers
+			 * if x is negative, add 7
+			 * if x is positive, add 9
+			 * if z is negative, add 7
+			 * if z is positive, add 9
+			 *
+			 * Result:
+			 * 1. Each province border is inset from the chunk border by 6 blocks
+			 * 2. The border on the sea takes the appearance of a single line
+			 * 3. The border between 2 provinces takes the appearance of a double line,
+			 *    with 2 blocks in between each line.
+			 *
+			 * NOTE ABOUT THE DOUBLE LINE:
+			 * I was initially aiming for a single line but it might not be worth it because:
+			 * 1. A double line has benefits:
+			 *   - It's friendly to the processor
+			 *   - It looks cool
+			 *   - The single-line sea border looks like it was done on purpose
+			 * 2. A single line has problems:
+			 *   - If you simply bring the lines together, you'll probably get visual artefacts
+			 *   - If you move the lines next to each other, you'll probably get visual artefacts
+			 *   - If you try to do draw the lines using area markers, you'll increase processor load, and probably still get visual artefacts.
+			 *   - On a sea border, the expected single line will either look slightly weaker or slightly thinner,
+			 *     while will most likely appear to users as a bug.
+			 * */
+			calculatePullStrengthFromNearbyProvince(drawableLineOfBorderCoord, province, tpFreeCoord);
+			if (tpFreeCoord.getX() < 0) {
+				x += 7;
+			} else if (tpFreeCoord.getX() > 0) {
+				x += 9;
+			}
+			if (tpFreeCoord.getZ() < 0) {
+				z += 7;
+			} else if (tpFreeCoord.getZ() > 0) {
+				z += 9;
+			}
+
+			points.add(Point.of(x, z));
+		}
+
+		//Convert line to polygon for display
+		Polygon polygonMarker  = Marker.polygon(points);
+		
+		//Set colour
+		MarkerOptions markerOptions = MarkerOptions.builder()
+			.strokeColor(borderColor)
+			.strokeWeight(borderWeight)
+			.strokeOpacity(borderOpacity)
+			.build();
+		
+		polygonMarker.markerOptions(markerOptions);
+
+		bordersLayer.addMarker(markerKey, polygonMarker);
+	}
+
+	protected void setProvinceMapStyles() {
+		Color requiredBorderColor;
+		int requiredBorderWeight;
+		double requiredBorderOpacity;
+		Color requiredFillColor;
+		double requiredFillOpacity;
+		Key markerKey;
+		//Cycle provinces
+		for(Province province: new HashSet<>(TownyProvincesDataHolder.getInstance().getProvincesSet())) {
+			//Set styles if needed
+			markerKey = Key.of(province.getId());
+			Marker polygonMarker = bordersLayer.registeredMarkers().get(markerKey);
+			if (polygonMarker == null) {
+				continue;
+			}
+			//Set border colour if needed
+			requiredBorderColor = new Color(province.getType().getBorderColour());
+			requiredBorderWeight = province.getType().getBorderWeight();
+			requiredBorderOpacity = province.getType().getBorderOpacity();
+			
+			requiredFillColor = new Color(province.getFillColour());
+			requiredFillOpacity = province.getFillOpacity();
+			
+			MarkerOptions oldOptions = polygonMarker.markerOptions();
+			MarkerOptions.Builder markerOptions = MarkerOptions.builder()
+				.stroke(oldOptions.stroke())
+				.strokeColor(requiredBorderColor)
+				.strokeWeight(requiredBorderWeight)
+				.strokeOpacity(requiredBorderOpacity)
+				.fill(oldOptions.fill())
+				.fillColor(requiredFillColor)
+				.fillOpacity(requiredFillOpacity)
+				.fillRule(oldOptions.fillRule())
+				.clickTooltip(oldOptions.clickTooltip())
+				.hoverTooltip(oldOptions.hoverTooltip());
+			
+			polygonMarker.markerOptions(markerOptions);
+		}
+	}
+}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/DisplayProvincesOnSquaremapAction.java
@@ -17,6 +17,7 @@ import xyz.jpenilla.squaremap.api.marker.MarkerOptions;
 import xyz.jpenilla.squaremap.api.marker.Polygon;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.util.*;
 import java.util.List;
 
@@ -114,12 +115,14 @@ public class DisplayProvincesOnSquaremapAction extends DisplayProvincesOnMapActi
 
 	@Override
 	void reloadAction() {
-		if (TownyProvincesSettings.getTownCostsIcon() == null) {
-			throw new RuntimeException("Town Costs Icon URL is not a valid image link");
+		BufferedImage configIcon = TownyProvincesSettings.getTownCostsIcon();
+		
+		if (configIcon == null) {
+			throw new RuntimeException("Town Costs Icon is not a valid image");
 		}
 		
 		if (api.iconRegistry().hasEntry(iconKey)) api.iconRegistry().unregister(iconKey);
-		api.iconRegistry().register(iconKey, TownyProvincesSettings.getTownCostsIcon());
+		api.iconRegistry().register(iconKey, configIcon);
 	}
 	
 	@Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: Goosius
 website: 'http://townyadvanced.github.io'
 prefix: ${project.artifactId}
 depend: [Towny]
-softdepend: [dynmap, Pl3xMap, BlueMap]
+softdepend: [dynmap, Pl3xMap, BlueMap, squaremap]
 
 description: Automatically divides the map up into one-town-only provinces, reducing staff workload and server toxicity.
 


### PR DESCRIPTION
Closes #44 

Adds SquareMap support

This has been tested against:
1.20.4 Paper (with, and without map plugin)
1.20.4 Spigot (with, and without map plugin)
1.16.5 Paper (without mappers - no support for 1.16.5)
1.16.5 Spigot (without mappers - as above)
1.18.1 Paper (with, and without map plugin - this is the lowest version supported by SquareMap, using an old version)

PR has passed all of my extensive testing with no exceptions thrown or unintended results (results are recorded in a thread in TownyProvinces channel on Towny Discord for this)


Additionally this updates the Pl3xMap dependency to 1.20.4 in pom.xml - This requires no other changes, compiles the same and was done purely as the version there is no longer available. - I didn't think this was worth such a tiny PR on its own as this was being done also.

