### PR TITLE
Fix for /tpra command not working (#130)

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
@@ -17,6 +17,11 @@ public class LandValidationTaskController {
 	private static LandvalidationTask landValidationTask = null;
 	private static ScheduledTask landValidationScheduledTask = null;
 	public static void startTask() {
+		//Cancel any existing scheduled task first, so a double start can't orphan
+		//a running async job whose handle we'd otherwise lose.
+		if (landValidationScheduledTask != null) {
+			landValidationScheduledTask.cancel();
+		}
 		landValidationTask = new LandvalidationTask();
 		landValidationScheduledTask = TownyProvinces.getPlugin().getScheduler().runAsync(landValidationTask);
 //		landValidationTask.runTaskAsynchronously(TownyProvinces.getPlugin());

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/land_validation/LandValidationTaskController.java
@@ -1,6 +1,7 @@
 package io.github.townyadvanced.townyprovinces.jobs.land_validation;
 
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.scheduling.ScheduledTask;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
 
@@ -14,9 +15,10 @@ public class LandValidationTaskController {
 	}
 
 	private static LandvalidationTask landValidationTask = null;
+	private static ScheduledTask landValidationScheduledTask = null;
 	public static void startTask() {
 		landValidationTask = new LandvalidationTask();
-		TownyProvinces.getPlugin().getScheduler().runAsync(landValidationTask);
+		landValidationScheduledTask = TownyProvinces.getPlugin().getScheduler().runAsync(landValidationTask);
 //		landValidationTask.runTaskAsynchronously(TownyProvinces.getPlugin());
 		landValidationJobStatus = LandValidationJobStatus.STARTED;
 		Messaging.sendGlobalMessage(Translatable.of("msg_land_validation_job_started"));
@@ -24,8 +26,10 @@ public class LandValidationTaskController {
 	
 	public static void stopTask() {
 		if(landValidationTask != null) {
-			landValidationTask.cancel();
+			if (landValidationScheduledTask != null)
+				landValidationScheduledTask.cancel();
 			landValidationTask = null;
+			landValidationScheduledTask = null;
 			landValidationJobStatus = LandValidationJobStatus.STOPPED;
 			Messaging.sendGlobalMessage(Translatable.of("msg_land_validation_job_stopped"));
 		}
@@ -33,8 +37,10 @@ public class LandValidationTaskController {
 
 	public static void pauseTask() {
 		if(landValidationTask != null) {
-			landValidationTask.cancel();
+			if (landValidationScheduledTask != null)
+				landValidationScheduledTask.cancel();
 			landValidationTask = null;
+			landValidationScheduledTask = null;
 			landValidationJobStatus = LandValidationJobStatus.PAUSED;
 			Messaging.sendGlobalMessage(Translatable.of("msg_land_validation_job_paused"));
 		}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
@@ -55,12 +55,13 @@ public class MapDisplayTaskController {
 	}
 
 	public static void endTask() {
-		if(mapDisplayTask != null) {
-			if (mapDisplayScheduledTask != null)
-				mapDisplayScheduledTask.cancel();
-			mapDisplayTask = null;
-			mapDisplayScheduledTask = null;
+		//Cancellation is driven by the scheduled task handle, so guard on it
+		//(can't be skipped if the runnable ref and the handle ever diverge).
+		if (mapDisplayScheduledTask != null) {
+			mapDisplayScheduledTask.cancel();
 		}
+		mapDisplayTask = null;
+		mapDisplayScheduledTask = null;
 	}
 
 	static void setFullProvinceColoursRefreshRequested(boolean b) {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/map_display/MapDisplayTaskController.java
@@ -1,4 +1,5 @@
 package io.github.townyadvanced.townyprovinces.jobs.map_display;
+import com.palmergames.bukkit.towny.scheduling.ScheduledTask;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 
@@ -8,6 +9,7 @@ import java.util.List;
 public class MapDisplayTaskController {
 	private static final List<DisplayProvincesOnMapAction> mapDisplayActions = new ArrayList<>();
 	private static MapDisplayTask mapDisplayTask = null;
+	private static ScheduledTask mapDisplayScheduledTask = null;
 	private static boolean fullProvinceColoursRefreshRequested;
 	private static boolean fullHomeBlockIconsRefreshRequest;
 	public static boolean startTask() {
@@ -19,7 +21,7 @@ public class MapDisplayTaskController {
 			fullProvinceColoursRefreshRequested = true;
 			fullHomeBlockIconsRefreshRequest = true;
 			mapDisplayTask = new MapDisplayTask();
-			TownyProvinces.getPlugin().getScheduler().runAsyncRepeating(mapDisplayTask, 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
+			mapDisplayScheduledTask = TownyProvinces.getPlugin().getScheduler().runAsyncRepeating(mapDisplayTask, 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
 			TownyProvinces.info("Map Display Job Started");
 			return true;
 		}
@@ -27,8 +29,8 @@ public class MapDisplayTaskController {
 	
 	public static void reloadIntegrations() {
 		
-		if (mapDisplayTask != null)
-			mapDisplayTask.cancel();
+		if (mapDisplayScheduledTask != null)
+			mapDisplayScheduledTask.cancel();
 		synchronized (TownyProvinces.MAP_DISPLAY_JOB_LOCK) {
 			synchronized (TownyProvinces.REGION_REGENERATION_JOB_LOCK) {
 				synchronized (TownyProvinces.PRICE_RECALCULATION_JOB_LOCK) {
@@ -40,7 +42,7 @@ public class MapDisplayTaskController {
 		}
 		requestFullMapRefresh();
 		mapDisplayTask = new MapDisplayTask();
-		TownyProvinces.getPlugin().getScheduler().runAsyncRepeating(mapDisplayTask, 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
+		mapDisplayScheduledTask = TownyProvinces.getPlugin().getScheduler().runAsyncRepeating(mapDisplayTask, 40, TownyProvincesSettings.getMapRefreshPeriodMilliseconds() * 20);
 	}
 
 	public static void requestFullMapRefresh() {
@@ -54,8 +56,10 @@ public class MapDisplayTaskController {
 
 	public static void endTask() {
 		if(mapDisplayTask != null) {
-			mapDisplayTask.cancel();
+			if (mapDisplayScheduledTask != null)
+				mapDisplayScheduledTask.cancel();
 			mapDisplayTask = null;
+			mapDisplayScheduledTask = null;
 		}
 	}
 


### PR DESCRIPTION
##TL;DR
This fixes /tpra command (#130)
There is a workaround - you can manually wipe plugin data folder so you can re-generate provinces with new config values.

## Problem

`MapDisplayTask` and `LandvalidationTask` extend `BukkitRunnable`, but they are scheduled through Towny's `TaskScheduler` (`runAsyncRepeating` / `runAsync`) rather than `BukkitRunnable`'s own `runTask*` methods. Their internal `taskId` therefore stays `-1`, so calling `BukkitRunnable.cancel()` throws `IllegalStateException("Not scheduled yet")`.

This crashes:

- **`/townyprovincesadmin reload`** — `MapDisplayTaskController.reloadIntegrations()` calls `mapDisplayTask.cancel()` on every reload (so the first reload after any startup fails with *"An unexpected error occurred trying to execute that command"*).
- **Land-validation stop / pause** — `LandValidationTaskController.stopTask()` / `pauseTask()`. This is the same `BukkitRunnable.cancel()` → "Not scheduled yet" crash reported in #130.

The existing `if (task != null)` guard (added in #122) does not cover the non-null-but-unscheduled state.

## Fix

Capture the `ScheduledTask` handle that `TaskScheduler.runAsync*` returns, and cancel **that** instead of the `BukkitRunnable`. This is what the scheduler API is designed for, works on both Bukkit and Folia, and also removes a latent double-schedule on map reload — previously `cancel()` threw *before* the replacement task was scheduled, so a bare `try/catch` would have left two repeating map-display tasks running.

`+18 / −8` across the two controllers (`MapDisplayTaskController`, `LandValidationTaskController`).

## Testing

- Builds clean against current `master` (Maven, JDK 21).
- Reproduced on Paper 1.21.8 / Towny 0.103.0.1 with provinces generated: `/tpra reload` → `IllegalStateException: Not scheduled yet`.
- With this patch on the same server: `/tpra reload` (run repeatedly) and land-validation `start → stop` both run clean — `TownyProvinces Reloaded Successfully`, zero `Not scheduled yet` in the logs.

Fixes #130
