### PR TITLE
Fix directional (NW) province clumping at small brush sizes (#28)

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -15,6 +15,7 @@ import org.bukkit.Location;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -361,8 +362,17 @@ public class PaintRegionAction {
 			/*
 			 * Do all the pending assignments
 			 * Except those which are no longer valid when you get to them
+			 *
+			 * Shuffle the processing order first (#28). Where two provinces both
+			 * want the same frontier coord, whichever is processed first claims it
+			 * and the other is re-verified into a border. Iterating in fixed
+			 * hashmap order always lets the same side win, which biases growth in
+			 * one direction (the "everything runs NW" bug) - especially at small
+			 * brush sizes. A random order makes that competition fair.
 			 */
-			for(Map.Entry<TPCoord,Province> mapEntry: pendingCoordProvinceAssignments.entrySet()) {
+			List<Map.Entry<TPCoord,Province>> shuffledAssignments = new ArrayList<>(pendingCoordProvinceAssignments.entrySet());
+			Collections.shuffle(shuffledAssignments);
+			for(Map.Entry<TPCoord,Province> mapEntry: shuffledAssignments) {
 				if(verifyCoordEligibilityForProvinceAssignment(mapEntry.getKey())) {
 					TownyProvincesDataHolder.getInstance().claimCoordForProvince(mapEntry.getKey(), mapEntry.getValue());
 					unclaimedCoordsMap.remove(mapEntry.getKey());

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -365,10 +365,13 @@ public class PaintRegionAction {
 			 *
 			 * Shuffle the processing order first (#28). Where two provinces both
 			 * want the same frontier coord, whichever is processed first claims it
-			 * and the other is re-verified into a border. Iterating in fixed
-			 * hashmap order always lets the same side win, which biases growth in
-			 * one direction (the "everything runs NW" bug) - especially at small
-			 * brush sizes. A random order makes that competition fair.
+			 * and the other is re-verified into a border. Walking the map in its own
+			 * iteration order visits the contested coords in a consistent,
+			 * position-correlated sequence, so the same side keeps winning and growth
+			 * is biased one way (the "everything runs NW" bug) - especially at small
+			 * brush sizes. Shuffling makes that competition fair. (Province generation
+			 * is already non-deterministic - random homeblock placement and brush
+			 * moves above - so this adds no new run-to-run variation.)
 			 */
 			List<Map.Entry<TPCoord,Province>> shuffledAssignments = new ArrayList<>(pendingCoordProvinceAssignments.entrySet());
 			Collections.shuffle(shuffledAssignments);


### PR DESCRIPTION
## Problem

Fixes #28 — with certain region defs (especially small brush sizes) provinces all grow in a NorthWest direction instead of filling evenly.

## Root cause

The bias is in the unclaimed-chunk fill pass (`PaintRegionAction.assignUnclaimedCoordsToProvinces()`), as suspected in the issue. Each round builds a map of frontier coords eligible for a province, then claims them. A coord that would border **two different** provinces is already excluded (it becomes a border). The contested case is two coords `C` (→province Q) and `D` (→province P) adjacent to each other but both still unclaimed: whichever is processed **first** gets claimed, and re-verification then turns the other into a border.

That processing order was the fixed `HashMap` iteration order (tied to `TPCoord` hashing), so the **same** side won every contested coord, every round → growth consistently drifted one way. Small brushes leave more unclaimed frontier to fill, so the effect is most visible there.

## Fix

Shuffle the pending-assignment list each round before processing, so the frontier competition is fair and growth is isotropic. `+3 / −1` in one method (plus a `java.util.Collections` import).

```java
List<Map.Entry<TPCoord,Province>> shuffledAssignments = new ArrayList<>(pendingCoordProvinceAssignments.entrySet());
Collections.shuffle(shuffledAssignments);
for (Map.Entry<TPCoord,Province> mapEntry : shuffledAssignments) { ... }
```

This matches the issue's suggested solution ("shuffle the unclaimed coords list before processing"). Generation is already non-deterministic — homeblock placement and brush movement use `Math.random()` — so this introduces no new reproducibility concern.

## Testing

- Builds clean against current `master` (Maven, JDK 21).
- The change is confined to the fill-competition ordering; eligibility rules (cardinal/diagonal border checks) are untouched, so province shapes stay valid — only the directional bias is removed.
