### PR TITLE
Explain why a protected_location fails to generate (#98)

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -131,7 +131,10 @@ public class PaintRegionAction {
 			TownyProvinces.info("Now generating province at protected location: " + mapEntry.getKey());
 			province = generateProtectedProvince(mapEntry.getValue());
 			if(province == null) {
-				TownyProvinces.severe("Could not generate province at protected location: " + mapEntry.getKey());
+				Coord coord = Coord.parseCoord(mapEntry.getValue());
+				String reason = describeInvalidBrushPosition(coord.getX(), coord.getZ(), null);
+				TownyProvinces.severe("Could not generate province at protected location '" + mapEntry.getKey() + "': "
+						+ (reason != null ? reason : "unknown reason"));
 				return false;
 			} else {
 				TownyProvincesDataHolder.getInstance().addProvince(province);
@@ -306,6 +309,64 @@ public class PaintRegionAction {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Explain why a brush (province) cannot be placed at the given position.
+	 * Mirrors the checks in {@link #validateBrushPosition}, but returns a
+	 * human-readable reason instead of a bare boolean. Used to enrich the error
+	 * shown when a configured protected_location fails to generate (#98).
+	 * <p>
+	 * Only called on the (rare) failure path, so - unlike validateBrushPosition,
+	 * which runs in the generation hot loop - it can afford to build a message.
+	 *
+	 * @return the reason the position is invalid, or null if it is actually valid
+	 */
+	private String describeInvalidBrushPosition(int brushPositionCoordX, int brushPositionCoordZ, Province provinceBeingPainted) {
+		//Off the edge of the map / region
+		if (brushPositionCoordX < mapMinXCoord
+				|| brushPositionCoordX > mapMaxXCoord
+				|| brushPositionCoordZ < mapMinZCoord
+				|| brushPositionCoordZ > mapMaxZCoord) {
+			return "it is outside the region bounds - homeblock chunk " + brushPositionCoordX + "," + brushPositionCoordZ
+					+ " is not within x[" + mapMinXCoord + ".." + mapMaxXCoord + "] z[" + mapMinZCoord + ".." + mapMaxZCoord + "]";
+		}
+		//Overlapping, or too close to, another province
+		int brushMinCoordX = brushPositionCoordX - region.getBrushSquareRadiusInChunks();
+		int brushMaxCoordX = brushPositionCoordX + region.getBrushSquareRadiusInChunks();
+		int brushMinCoordZ = brushPositionCoordZ - region.getBrushSquareRadiusInChunks();
+		int brushMaxCoordZ = brushPositionCoordZ + region.getBrushSquareRadiusInChunks();
+		for(int x = brushMinCoordX -1; x <= (brushMaxCoordX +1); x++) {
+			for(int z = brushMinCoordZ -1; z <= (brushMaxCoordZ +1); z++) {
+				Province province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(x,z);
+				if(province != null && province != provinceBeingPainted) {
+					String conflictName = getProtectedLocationNameAt(province.getHomeBlock());
+					if (conflictName != null) {
+						return "it is too close to another protected location ('" + conflictName
+								+ "') - their claim areas overlap at chunk " + x + "," + z
+								+ ". Move them further apart or reduce the brush size.";
+					} else {
+						return "it is too close to an existing province - claim areas overlap at chunk " + x + "," + z
+								+ ". Move it further into open space or reduce the brush size.";
+					}
+				}
+			}
+		}
+		return null; //Position is actually valid
+	}
+
+	/**
+	 * @return the name of the configured protected_location whose homeblock sits
+	 *         at the given coord, or null if none does.
+	 */
+	private String getProtectedLocationNameAt(TPCoord homeBlockCoord) {
+		for (Map.Entry<String, Location> mapEntry : region.getProtectedLocations().entrySet()) {
+			Coord coord = Coord.parseCoord(mapEntry.getValue());
+			if (coord.getX() == homeBlockCoord.getX() && coord.getZ() == homeBlockCoord.getZ()) {
+				return mapEntry.getKey();
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/jobs/province_generation/PaintRegionAction.java
@@ -312,10 +312,13 @@ public class PaintRegionAction {
 	}
 
 	/**
-	 * Explain why a brush (province) cannot be placed at the given position.
-	 * Mirrors the checks in {@link #validateBrushPosition}, but returns a
-	 * human-readable reason instead of a bare boolean. Used to enrich the error
-	 * shown when a configured protected_location fails to generate (#98).
+	 * Explain why a brush (province) cannot be placed at the given position, to
+	 * enrich the error shown when a configured protected_location fails to
+	 * generate (#98).
+	 * <p>
+	 * The verdict (valid vs invalid) is taken from {@link #validateBrushPosition},
+	 * so the two can never disagree; this method only classifies an already-failed
+	 * position into a human-readable reason.
 	 * <p>
 	 * Only called on the (rare) failure path, so - unlike validateBrushPosition,
 	 * which runs in the generation hot loop - it can afford to build a message.
@@ -323,6 +326,12 @@ public class PaintRegionAction {
 	 * @return the reason the position is invalid, or null if it is actually valid
 	 */
 	private String describeInvalidBrushPosition(int brushPositionCoordX, int brushPositionCoordZ, Province provinceBeingPainted) {
+		//Single source of truth for the verdict: defer to validateBrushPosition, so the
+		//explanation can never disagree with the actual check - even if that check gains
+		//a new rejection rule, we still correctly report the position as invalid.
+		if (validateBrushPosition(brushPositionCoordX, brushPositionCoordZ, provinceBeingPainted)) {
+			return null;
+		}
 		//Off the edge of the map / region
 		if (brushPositionCoordX < mapMinXCoord
 				|| brushPositionCoordX > mapMaxXCoord
@@ -352,7 +361,10 @@ public class PaintRegionAction {
 				}
 			}
 		}
-		return null; //Position is actually valid
+		//validateBrushPosition rejected the position for a reason this explainer does
+		//not recognise (e.g. a rule added to it since). Report that honestly rather
+		//than guessing a wrong reason or claiming the position is valid.
+		return "it failed brush-placement validation (no specific reason could be determined)";
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Fixes #98 — when a configured `protected_location` can't be generated, the log only says:

```
Could not generate province at protected location: <name>
```

…with no reason, so it's hard to tell *why* it failed (off the map? too close to another protected location?).

## Fix

On the failure path, report the actual cause. `generateProtectedProvince()` returns null only when `validateBrushPosition()` rejects the spot, which happens for two knowable reasons at generation time:

1. **Outside the region bounds** — now printed with the offending homeblock chunk and the valid x/z range.
2. **Too close to / overlapping another province** — now printed with the overlapping chunk, and when the conflicting province is itself a configured `protected_location`, it's **named** (the most common case, since protected locations are generated first):

```
Could not generate province at protected location 'rome': it is too close to another
protected location ('paris') - their claim areas overlap at chunk 37,-1090.
Move them further apart or reduce the brush size.
```

The new `describeInvalidBrushPosition(...)` mirrors `validateBrushPosition(...)` but is **only invoked once generation has already failed**, so the generation hot loop keeps its cheap boolean check — no per-move string building, no perf impact on normal generation. (Sea/biome reasons aren't knowable here — land validation runs as a separate pass after generation — so only the two generation-time causes are reported.)

`+~55 / −1`, one file.

## Testing

- Builds clean against current `master` (Maven, JDK 21).
- Pure error-message enrichment on the existing `null` failure branch; the success path and `validateBrushPosition` are unchanged.
