### PR TITLE
Add province_prices_enabled config toggle to disable TP pricing (#115)

### DIFF
--- a/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/listeners/TownyListener.java
@@ -102,7 +102,8 @@ public class TownyListener implements Listener {
 			return;
 		}
 		// Set the Town's creation cost to the value dictated by TownyProvines.
-		if (TownySettings.isUsingEconomy() && province.getNewTownCost() > 0) {
+		// (skipped if province pricing is disabled - Towny's own price then applies)
+		if (TownySettings.isUsingEconomy() && TownyProvincesSettings.isProvincePricesEnabled() && province.getNewTownCost() > 0) {
 			int regionSettlementCost = (int)(TownyProvincesSettings.isBiomeCostAdjustmentsEnabled() ? province.getBiomeAdjustedNewTownCost() : province.getNewTownCost());
 			double totalNewTownCost = TownySettings.getNewTownPrice() + regionSettlementCost;
 			event.setPrice(totalNewTownCost);
@@ -111,7 +112,8 @@ public class TownyListener implements Listener {
 
 	@EventHandler(ignoreCancelled = true)
 	public void on(TownUpkeepCalculationEvent event) {
-		if (!TownyProvincesSettings.isTownyProvincesEnabled() || !TownySettings.isUsingEconomy()) {
+		if (!TownyProvincesSettings.isTownyProvincesEnabled() || !TownySettings.isUsingEconomy()
+				|| !TownyProvincesSettings.isProvincePricesEnabled()) {
 			return;
 		}
 		//Can't work it if the town has no homeblock

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/ConfigNodes.java
@@ -43,6 +43,15 @@ public enum ConfigNodes {
 		"# The value to both newTownCost and upkeepTownCost.",
 		"# The value is a proportion of the 'average regional province price without outliers', if you know what I mean....",
 		"# If you don't know what I mean, use caution when adjusting."),
+	PROVINCE_PRICES_ENABLED(
+		"province_prices_enabled",
+		"true",
+		"",
+		"# If true, TownyProvinces applies a per-province new-town cost and upkeep,",
+		"# on top of Towny's own pricing.",
+		"# If false, TownyProvinces does not touch town pricing at all - Towny's",
+		"# own new-town price and upkeep apply instead. Use this if you want",
+		"# province shapes/biomes without TownyProvinces rewriting your economy."),
 	BIOME_COST_ADJUSTMENTS(
 		"biome_cost_adjustments",
 		"",

--- a/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/settings/TownyProvincesSettings.java
@@ -251,6 +251,10 @@ public class TownyProvincesSettings {
 		}
 	}
 	
+	public static boolean isProvincePricesEnabled() {
+		return Settings.getBoolean(ConfigNodes.PROVINCE_PRICES_ENABLED);
+	}
+
 	public static boolean isBiomeCostAdjustmentsEnabled() {
 		return Settings.getBoolean(ConfigNodes.BIOME_COST_ADJUSTMENTS_ENABLED);
 	}


### PR DESCRIPTION
## Problem

Fixes #115 — there's no way to turn off TownyProvinces' per-province pricing short of editing every province by hand (the requester has 1000+). Some servers want province **shapes/biomes** but would rather keep Towny's own upkeep/claim economy.

## Fix

Add a single config switch:

```yaml
province_prices_enabled: true   # default - no behaviour change
```

When set to `false`, TownyProvinces stops imposing its pricing and falls back to vanilla Towny:

- **New-town cost** (`NewTownEvent`) — the per-province settlement cost is no longer added; Towny's own `getNewTownPrice()` applies.
- **Upkeep** (`TownUpkeepCalculationEvent`) — the province upkeep surcharge is no longer added.

Both are gated at their existing application points in `TownyListener` via a new `TownyProvincesSettings.isProvincePricesEnabled()` accessor. The price-recalculation job is intentionally left running, so the toggle can be flipped back on without regenerating provinces.

The config node is added to `ConfigNodes` (config.yml is generated from it), so existing configs pick up the new key with its `true` default automatically.

`+~20` lines across `ConfigNodes`, `TownyProvincesSettings`, `TownyListener`.

## Testing

- Builds clean against current `master` (Maven, JDK 21).
- Default (`true`) preserves current behaviour exactly; the only new branch is the `false` short-circuit at the two pricing handlers.
