### PR TITLE
Add PlaceholderAPI expansion for provinces (#126)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
           <id>Modrinth</id>
           <url>https://api.modrinth.com/maven</url>
       </repository>
+      <repository>
+          <id>placeholderapi</id>
+          <url>https://repo.extendedclip.com/releases/</url>
+      </repository>
   </repositories>
 
   <dependencies>
@@ -72,6 +76,12 @@
           <groupId>xyz.jpenilla</groupId>
           <artifactId>squaremap-api</artifactId>
           <version>1.1.12</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>me.clip</groupId>
+          <artifactId>placeholderapi</artifactId>
+          <version>2.11.6</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>

--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -12,6 +12,7 @@ import com.palmergames.bukkit.util.Version;
 import io.github.townyadvanced.townyprovinces.commands.TownyProvincesAdminCommand;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
+import io.github.townyadvanced.townyprovinces.integrations.TownyProvincesPlaceholders;
 import io.github.townyadvanced.townyprovinces.jobs.map_display.*;
 import io.github.townyadvanced.townyprovinces.listeners.TownyListener;
 import io.github.townyadvanced.townyprovinces.messaging.Messaging;
@@ -72,10 +73,28 @@ public class TownyProvinces extends JavaPlugin {
 			return;
 		}
 
-		//Load optional stuff 
+		//Load optional stuff
 		loadIntegrations();
+		registerPlaceholderExpansion();
 
 		info("TownyProvinces Loaded Successfully");
+	}
+
+	/**
+	 * Register the PlaceholderAPI expansion, if PlaceholderAPI is installed.
+	 * Done separately from {@link #loadIntegrations()} so it is not affected by
+	 * whether a map plugin is present.
+	 */
+	private void registerPlaceholderExpansion() {
+		if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+			try {
+				new TownyProvincesPlaceholders(this).register();
+				info("Found PlaceholderAPI. Enabling PlaceholderAPI integration.");
+			} catch (Throwable t) {
+				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling PlaceholderAPI integration: " + t.getMessage());
+				t.printStackTrace();
+			}
+		}
 	}
 
 	private void printSickAsciiArt() {

--- a/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/TownyProvinces.java
@@ -12,6 +12,7 @@ import com.palmergames.bukkit.util.Version;
 import io.github.townyadvanced.townyprovinces.commands.TownyProvincesAdminCommand;
 import io.github.townyadvanced.townyprovinces.data.DataHandlerUtil;
 import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
+import io.github.townyadvanced.townyprovinces.integrations.PlayerProvinceTracker;
 import io.github.townyadvanced.townyprovinces.integrations.TownyProvincesPlaceholders;
 import io.github.townyadvanced.townyprovinces.jobs.map_display.*;
 import io.github.townyadvanced.townyprovinces.listeners.TownyListener;
@@ -28,6 +29,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.logging.Level;
 
 import static com.palmergames.util.JavaUtil.classExists;
 
@@ -89,10 +91,10 @@ public class TownyProvinces extends JavaPlugin {
 		if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
 			try {
 				new TownyProvincesPlaceholders(this).register();
+				getServer().getPluginManager().registerEvents(new PlayerProvinceTracker(), this);
 				info("Found PlaceholderAPI. Enabling PlaceholderAPI integration.");
-			} catch (Throwable t) {
-				Messaging.sendErrorMsg(Bukkit.getConsoleSender(), "Problem enabling PlaceholderAPI integration: " + t.getMessage());
-				t.printStackTrace();
+			} catch (Exception e) {
+				getLogger().log(Level.SEVERE, "Problem enabling PlaceholderAPI integration", e);
 			}
 		}
 	}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/integrations/PlayerProvinceTracker.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/integrations/PlayerProvinceTracker.java
@@ -1,0 +1,107 @@
+package io.github.townyadvanced.townyprovinces.integrations;
+
+import com.palmergames.bukkit.towny.object.Coord;
+import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
+import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks, per online player, the TownyProvinces {@link Province} they are
+ * currently standing in, so {@link TownyProvincesPlaceholders} can answer
+ * without touching the Bukkit entity/world API.
+ * <p>
+ * PlaceholderAPI placeholders are commonly resolved off the main thread (TAB,
+ * scoreboard and chat plugins do this by default). Calling
+ * {@code player.getWorld()} / {@code player.getLocation()} from such a thread is
+ * unsafe on Paper and is a hard error on Folia, where an entity may only be
+ * accessed from its owning region thread. The province is therefore (re)computed
+ * here - inside player event handlers, which always run on the correct thread for
+ * that player on both Bukkit and Folia - and published into a thread-safe map
+ * that the placeholder only reads.
+ * <p>
+ * Absence from the map means "not in a province" (on a border, or outside the
+ * TownyProvinces world). {@link ConcurrentHashMap} cannot hold null values, so a
+ * null province is stored as a removal rather than a mapping.
+ */
+public class PlayerProvinceTracker implements Listener {
+
+	private static final ConcurrentHashMap<UUID, Province> PLAYER_PROVINCE = new ConcurrentHashMap<>();
+
+	/**
+	 * @return the province the given player currently stands in, or null if they
+	 *         are in no province (border / non-TP world) or not yet tracked.
+	 */
+	@Nullable
+	public static Province getProvince(UUID playerId) {
+		return PLAYER_PROVINCE.get(playerId);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onJoin(PlayerJoinEvent event) {
+		refresh(event.getPlayer(), event.getPlayer().getLocation());
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onTeleport(PlayerTeleportEvent event) {
+		if (event.getTo() != null) {
+			refresh(event.getPlayer(), event.getTo());
+		}
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onMove(PlayerMoveEvent event) {
+		Location from = event.getFrom();
+		Location to = event.getTo();
+		if (to == null) {
+			return;
+		}
+		//Province granularity is a Towny Coord (a chunk), so only recompute when the
+		//player actually crosses a chunk boundary - PlayerMoveEvent fires on every
+		//sub-block movement and look-around.
+		if (from.getWorld() == to.getWorld()
+				&& (from.getBlockX() >> 4) == (to.getBlockX() >> 4)
+				&& (from.getBlockZ() >> 4) == (to.getBlockZ() >> 4)) {
+			return;
+		}
+		refresh(event.getPlayer(), to);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onQuit(PlayerQuitEvent event) {
+		PLAYER_PROVINCE.remove(event.getPlayer().getUniqueId());
+	}
+
+	/**
+	 * Recompute and cache the player's province. Runs on the player's own thread
+	 * (Bukkit main / Folia region), so location and world access here is safe.
+	 */
+	private void refresh(Player player, Location location) {
+		UUID id = player.getUniqueId();
+		World tpWorld = TownyProvincesSettings.getWorld();
+		if (tpWorld == null || location.getWorld() == null || !location.getWorld().equals(tpWorld)) {
+			PLAYER_PROVINCE.remove(id);
+			return;
+		}
+		Coord coord = Coord.parseCoord(location);
+		Province province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(coord.getX(), coord.getZ());
+		if (province == null) {
+			PLAYER_PROVINCE.remove(id);
+		} else {
+			PLAYER_PROVINCE.put(id, province);
+		}
+	}
+}

--- a/src/main/java/io/github/townyadvanced/townyprovinces/integrations/TownyProvincesPlaceholders.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/integrations/TownyProvincesPlaceholders.java
@@ -1,14 +1,11 @@
 package io.github.townyadvanced.townyprovinces.integrations;
 
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Town;
 import io.github.townyadvanced.townyprovinces.TownyProvinces;
-import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
 import io.github.townyadvanced.townyprovinces.objects.Province;
 import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,9 +20,10 @@ import java.util.Locale;
  * config.yml - these report the real, region-set province cost (the same value
  * TownyProvinces charges and shows on the map).
  * <p>
- * All placeholders resolve by the player's location and return an empty string
- * when the player is not standing inside a province (e.g. on a border, or
- * outside the TownyProvinces world).
+ * Placeholders resolve from a per-player cache maintained by
+ * {@link PlayerProvinceTracker} (so they are safe to query off the main thread)
+ * and return an empty string when the player is not standing inside a province
+ * (e.g. on a border, or outside the TownyProvinces world).
  *
  * <ul>
  *   <li>{@code %townyprovinces_is_province%} - true/false</li>
@@ -74,13 +72,10 @@ public class TownyProvincesPlaceholders extends PlaceholderExpansion {
 		if (player == null || !TownyProvincesSettings.isTownyProvincesEnabled()) {
 			return "";
 		}
-		//Province data only exists in the TownyProvinces world
-		World tpWorld = TownyProvincesSettings.getWorld();
-		if (tpWorld == null || !player.getWorld().equals(tpWorld)) {
-			return "";
-		}
-		Coord coord = Coord.parseCoord(player.getLocation());
-		Province province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(coord.getX(), coord.getZ());
+		//Resolved from a thread-safe cache rather than the player's live location:
+		//PlaceholderAPI is frequently queried off the main thread, where Bukkit
+		//entity/world access is unsafe (and illegal on Folia). See PlayerProvinceTracker.
+		Province province = PlayerProvinceTracker.getProvince(player.getUniqueId());
 		boolean inProvince = province != null;
 
 		switch (params.toLowerCase(Locale.ROOT)) {
@@ -93,7 +88,9 @@ public class TownyProvincesPlaceholders extends PlaceholderExpansion {
 			case "new_town_cost":
 				return inProvince ? formatCost(getEffectiveNewTownCost(province)) : "";
 			case "total_new_town_cost":
-				return inProvince ? formatCost(TownySettings.getNewTownPrice() + getEffectiveNewTownCost(province)) : "";
+				//Mirror TownyListener: the province component is truncated to a whole
+				//number first, then added to Towny's base new-town price.
+				return inProvince ? formatCost(TownySettings.getNewTownPrice() + (int) getEffectiveNewTownCost(province)) : "";
 			case "upkeep_cost":
 				return inProvince ? formatCost(getEffectiveUpkeepCost(province)) : "";
 			case "town":
@@ -121,8 +118,9 @@ public class TownyProvincesPlaceholders extends PlaceholderExpansion {
 	}
 
 	/**
-	 * Costs are charged as whole numbers (see TownyListener), so report them the
-	 * same way.
+	 * Province costs are charged as whole numbers - TownyListener casts them to int
+	 * (regionSettlementCost / regionUpkeepCost) - so the placeholders report them
+	 * the same way.
 	 */
 	private String formatCost(double cost) {
 		return String.valueOf((int) cost);

--- a/src/main/java/io/github/townyadvanced/townyprovinces/integrations/TownyProvincesPlaceholders.java
+++ b/src/main/java/io/github/townyadvanced/townyprovinces/integrations/TownyProvincesPlaceholders.java
@@ -1,0 +1,130 @@
+package io.github.townyadvanced.townyprovinces.integrations;
+
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.Coord;
+import com.palmergames.bukkit.towny.object.Town;
+import io.github.townyadvanced.townyprovinces.TownyProvinces;
+import io.github.townyadvanced.townyprovinces.data.TownyProvincesDataHolder;
+import io.github.townyadvanced.townyprovinces.objects.Province;
+import io.github.townyadvanced.townyprovinces.settings.TownyProvincesSettings;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+
+/**
+ * PlaceholderAPI expansion exposing the TownyProvinces province at a player's
+ * current location (#126).
+ * <p>
+ * Unlike Towny's own placeholders - which return the flat claim value from
+ * config.yml - these report the real, region-set province cost (the same value
+ * TownyProvinces charges and shows on the map).
+ * <p>
+ * All placeholders resolve by the player's location and return an empty string
+ * when the player is not standing inside a province (e.g. on a border, or
+ * outside the TownyProvinces world).
+ *
+ * <ul>
+ *   <li>{@code %townyprovinces_is_province%} - true/false</li>
+ *   <li>{@code %townyprovinces_province_id%} - internal province id</li>
+ *   <li>{@code %townyprovinces_province_type%} - civilized / sea / wasteland</li>
+ *   <li>{@code %townyprovinces_new_town_cost%} - province component of the new-town cost</li>
+ *   <li>{@code %townyprovinces_total_new_town_cost%} - Towny base price + province component</li>
+ *   <li>{@code %townyprovinces_upkeep_cost%} - province upkeep component</li>
+ *   <li>{@code %townyprovinces_town%} - name of the town occupying the province, if any</li>
+ * </ul>
+ */
+public class TownyProvincesPlaceholders extends PlaceholderExpansion {
+
+	private final TownyProvinces plugin;
+
+	public TownyProvincesPlaceholders(TownyProvinces plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public @NotNull String getIdentifier() {
+		return "townyprovinces";
+	}
+
+	@Override
+	public @NotNull String getAuthor() {
+		return "TownyAdvanced";
+	}
+
+	@Override
+	public @NotNull String getVersion() {
+		return plugin.getPluginMeta().getVersion();
+	}
+
+	/**
+	 * Keep the expansion registered across PlaceholderAPI reloads, since it is
+	 * provided by this plugin rather than downloaded from the eCloud.
+	 */
+	@Override
+	public boolean persist() {
+		return true;
+	}
+
+	@Override
+	public @Nullable String onPlaceholderRequest(Player player, @NotNull String params) {
+		if (player == null || !TownyProvincesSettings.isTownyProvincesEnabled()) {
+			return "";
+		}
+		//Province data only exists in the TownyProvinces world
+		World tpWorld = TownyProvincesSettings.getWorld();
+		if (tpWorld == null || !player.getWorld().equals(tpWorld)) {
+			return "";
+		}
+		Coord coord = Coord.parseCoord(player.getLocation());
+		Province province = TownyProvincesDataHolder.getInstance().getProvinceAtCoord(coord.getX(), coord.getZ());
+		boolean inProvince = province != null;
+
+		switch (params.toLowerCase(Locale.ROOT)) {
+			case "is_province":
+				return String.valueOf(inProvince);
+			case "province_id":
+				return inProvince ? province.getId() : "";
+			case "province_type":
+				return inProvince ? province.getType().name().toLowerCase(Locale.ROOT) : "";
+			case "new_town_cost":
+				return inProvince ? formatCost(getEffectiveNewTownCost(province)) : "";
+			case "total_new_town_cost":
+				return inProvince ? formatCost(TownySettings.getNewTownPrice() + getEffectiveNewTownCost(province)) : "";
+			case "upkeep_cost":
+				return inProvince ? formatCost(getEffectiveUpkeepCost(province)) : "";
+			case "town":
+				if (!inProvince) {
+					return "";
+				}
+				Town town = province.getTownOrNull();
+				return town != null ? town.getName() : "";
+			default:
+				//Unknown placeholder - let PlaceholderAPI show it unresolved
+				return null;
+		}
+	}
+
+	private double getEffectiveNewTownCost(Province province) {
+		return TownyProvincesSettings.isBiomeCostAdjustmentsEnabled()
+				? province.getBiomeAdjustedNewTownCost()
+				: province.getNewTownCost();
+	}
+
+	private double getEffectiveUpkeepCost(Province province) {
+		return TownyProvincesSettings.isBiomeCostAdjustmentsEnabled()
+				? province.getBiomeAdjustedUpkeepTownCost()
+				: province.getUpkeepTownCost();
+	}
+
+	/**
+	 * Costs are charged as whole numbers (see TownyListener), so report them the
+	 * same way.
+	 */
+	private String formatCost(double cost) {
+		return String.valueOf((int) cost);
+	}
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: Goosius
 website: 'http://townyadvanced.github.io'
 prefix: ${project.artifactId}
 depend: [Towny]
-softdepend: [dynmap, Pl3xMap, BlueMap, squaremap]
+softdepend: [dynmap, Pl3xMap, BlueMap, squaremap, PlaceholderAPI]
 folia-supported: true
 
 description: Automatically divides the map up into one-town-only provinces, reducing staff workload and server toxicity.


### PR DESCRIPTION
## Problem

Fixes #126 — Towny's own placeholders return the flat claim value from `config.yml`, which isn't the real cost once TownyProvinces sets per-region province prices (the value shown on the map). There were no TownyProvinces-specific placeholders.

## Fix

Add a PlaceholderAPI expansion (identifier `townyprovinces`) that resolves the province at the **player's current location** and exposes its real data:

| Placeholder | Returns |
|---|---|
| `%townyprovinces_is_province%` | `true` / `false` |
| `%townyprovinces_province_id%` | internal province id |
| `%townyprovinces_province_type%` | `civilized` / `sea` / `wasteland` |
| `%townyprovinces_new_town_cost%` | province component of the new-town cost (biome-adjusted if enabled) |
| `%townyprovinces_total_new_town_cost%` | Towny base price + province component (what's actually charged) |
| `%townyprovinces_upkeep_cost%` | province upkeep component |
| `%townyprovinces_town%` | name of the town occupying the province, if any |

All return `""` when the player isn't inside a province (on a border, or outside the TownyProvinces world). Cost values use the same logic `TownyListener` uses to charge, so they match reality.

## Implementation

- New `integrations/TownyProvincesPlaceholders extends PlaceholderExpansion`.
- Registered in `onEnable()` behind an `isPluginEnabled("PlaceholderAPI")` guard (separate from `loadIntegrations()` so it doesn't depend on a map plugin being present); wrapped in try/catch like the other optional integrations. `persist()` returns true so it survives `/papi reload`.
- `PlaceholderAPI` added as a `provided` dependency (extendedclip repo) and to `softdepend` in `plugin.yml`. No-ops cleanly when PlaceholderAPI is absent.

## Testing

- Builds and **packages** clean against current `master` (Maven, JDK 21); the expansion class and updated `plugin.yml` are present in the built jar.
- Read-only, location-based; resolves via the same `getProvinceAtCoord` lookup the listeners use.
